### PR TITLE
Fix shellcheck issues in remaining scripts

### DIFF
--- a/do_the_internet.sh
+++ b/do_the_internet.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # # Sync offpunk
-cd $HOME/src/AV-98-offline
+cd "$HOME"/src/AV-98-offline || exit
 python3 offpunk.py --sync
 
 # Sync email

--- a/ghreadme.sh
+++ b/ghreadme.sh
@@ -5,4 +5,4 @@ gh_user=$(echo "${gh_url}" | cut -f4 -d '/')
 gh_repo=$(echo "${gh_url}" | cut -f5 -d '/')
 gh_response=$(curl -s "https://api.github.com/repos/${gh_user}/${gh_repo}/readme" || echo "nope")
 has_content=$(echo "$gh_response" | jq -r 'has("content")')
-[[ $has_content == "true" ]] && echo "$gh_response" | jq -r .content | base64 -d| bat --language=markdown --style=plain
+[[ $has_content == "true" ]] && echo "$gh_response" | jq -r .content | base64 -d | less


### PR DESCRIPTION
## Summary
- Fixed shellcheck issues in `do_the_internet.sh` (SC2164: unsafe cd, SC2086: missing quotes)
- Updated `ghreadme.sh` to use `less` instead of `bat` for better compatibility

## Test plan
- [x] Verified shellcheck passes on both files
- [x] Tested `ghreadme.sh` with a real GitHub repo

Closes #9

🤖 Generated with [Claude Code](https://claude.ai/code)