### PR TITLE
Fix shellcheck issues in setup scripts

### DIFF
--- a/amfora/setup.sh
+++ b/amfora/setup.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-mkdir -p $HOME/.config/amfora
-ln -svf $DOTFILES_HOME/amfora/config.toml $HOME/.config/amfora/config.toml
+mkdir -p "$HOME"/.config/amfora
+ln -svf "$DOTFILES_HOME"/amfora/config.toml "$HOME"/.config/amfora/config.toml

--- a/dwm/setup.sh
+++ b/dwm/setup.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 
 dwm_path="$HOME/Projects/dwm"
-[ ! -d "$dwm_path" ] && git clone git@github.com:thavelick/dwm.git $dwm_path
-cd $dwm_path && sudo make install
+[ ! -d "$dwm_path" ] && git clone git@github.com:thavelick/dwm.git "$dwm_path"
+cd "$dwm_path" || exit
+sudo make install

--- a/fbterm/setup.sh
+++ b/fbterm/setup.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-mkdir -p $HOME/.config/fbterm
+mkdir -p "$HOME"/.config/fbterm
 
-ln -svf $DOTFILES_HOME/fbterm/fbtermrc $HOME/.config/fbterm/fbtermrc
+ln -svf "$DOTFILES_HOME"/fbterm/fbtermrc "$HOME"/.config/fbterm/fbtermrc
 

--- a/git/setup.sh
+++ b/git/setup.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-ln -svf $DOTFILES_HOME/git/gitconfig $HOME/.gitconfig 
+ln -svf "$DOTFILES_HOME"/git/gitconfig "$HOME"/.gitconfig 

--- a/neomutt/setup.sh
+++ b/neomutt/setup.sh
@@ -4,4 +4,4 @@
 mkdir -p "$HOME/.cache/mutt"
 
 # symlink .neomuttrc
-ln -svf $DOTFILES_HOME/neomutt/neomuttrc $HOME/.neomuttrc
+ln -svf "$DOTFILES_HOME"/neomutt/neomuttrc "$HOME"/.neomuttrc

--- a/waybar/setup.sh
+++ b/waybar/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 # symlink waybar config
-ln -svfn $DOTFILES_HOME/waybar $HOME/.config/waybar
+ln -svfn "$DOTFILES_HOME"/waybar "$HOME"/.config/waybar
 
 
 

--- a/x11/setup.sh
+++ b/x11/setup.sh
@@ -2,5 +2,5 @@
 
 
 # symlink config
-ln -svf $DOTFILES_HOME/x11/xinitrc $HOME/.xinitrc
-ln -svf $DOTFILES_HOME/x11/Xresources $HOME/.Xresources
+ln -svf "$DOTFILES_HOME"/x11/xinitrc "$HOME"/.xinitrc
+ln -svf "$DOTFILES_HOME"/x11/Xresources "$HOME"/.Xresources

--- a/zsh/setup.sh
+++ b/zsh/setup.sh
@@ -1,20 +1,20 @@
 #!/bin/sh
 
 zsh_plugins_path=$HOME/.zsh
-mkdir -p $zsh_plugins_path
+mkdir -p "$zsh_plugins_path"
 
 
 # install syntax highlighting
 syntax_highlight_path=$zsh_plugins_path/zsh-syntax-highlighting
-[ ! -d $syntax_highlight_path ] && \
+[ ! -d "$syntax_highlight_path" ] && \
 	git clone --depth=1 https://github.com/zsh-users/zsh-syntax-highlighting.git \
-	$syntax_highlight_path
+	"$syntax_highlight_path"
 
 # install autosuggestions
 suggestions_path=$zsh_plugins_path/zsh-autosuggestions
-[ ! -d $suggestions_path ] && \
+[ ! -d "$suggestions_path" ] && \
 	git clone --depth=1 https://github.com/zsh-users/zsh-autosuggestions.git \
-	$suggestions_path
+	"$suggestions_path"
 
 # symlink .zshrc
-ln -svf $DOTFILES_HOME/zsh/zshrc $HOME/.zshrc
+ln -svf "$DOTFILES_HOME"/zsh/zshrc "$HOME"/.zshrc


### PR DESCRIPTION
## Summary
- Fixed all shellcheck SC2086 issues by adding proper quoting around variables (`$DOTFILES_HOME`, `$HOME`)
- Fixed SC2164 issue by making unsafe `cd` command safe with `|| exit` in dwm/setup.sh
- Created automated `scratch/shellcheck_fix.sh` script for future shellcheck fixing
- Verified all setup.sh and install.sh files now pass shellcheck

## Files Fixed
- amfora/setup.sh
- dwm/setup.sh  
- fbterm/setup.sh
- git/setup.sh
- neomutt/setup.sh
- waybar/setup.sh
- x11/setup.sh
- zsh/setup.sh

## Test plan
- [x] All scripts pass shellcheck validation
- [x] Scripts maintain proper syntax with `bash -n` checks
- [x] Automated script available for future use in `scratch/shellcheck_fix.sh`

Fixes #5

🤖 Generated with [Claude Code](https://claude.ai/code)