### PR TITLE
Fix CI workflow shellcheck pattern and update CLAUDE.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,12 +48,12 @@ jobs:
     - name: Check shellcheck ratchet
       run: |
         # Count issues in PR branch (current)
-        CURRENT_COUNT=$(find . -name "*.sh" -o -name "init" | grep -v ".git" | grep -v "scratch" | xargs shellcheck 2>/dev/null | wc -l)
+        CURRENT_COUNT=$(find . -name "*.sh" -o -path "./river/init" | grep -v ".git" | grep -v "scratch" | xargs shellcheck 2>/dev/null | wc -l)
         echo "PR branch issues: $CURRENT_COUNT"
         
         # Switch to main and count issues
         git checkout origin/main
-        MAIN_COUNT=$(find . -name "*.sh" -o -name "init" | grep -v ".git" | grep -v "scratch" | xargs shellcheck 2>/dev/null | wc -l)
+        MAIN_COUNT=$(find . -name "*.sh" -o -path "./river/init" | grep -v ".git" | grep -v "scratch" | xargs shellcheck 2>/dev/null | wc -l)
         echo "Main branch issues: $MAIN_COUNT"
         
         # Compare and report

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ This repository contains a modular, portable zsh configuration.
 
 ### Development Workflow
 - Always do work on a new branch, not main
+- When working on a ticket, put the ticket number in commit message and PR
 - When user says "Review time":
   a. Make sure we're not on main branch
   b. Commit what we've done


### PR DESCRIPTION
## Summary
- Fix shellcheck CI to use `-path "./river/init"` instead of `-name "init"` to specifically target river/init file rather than any file named init
- Add guidance to CLAUDE.md about including ticket numbers in commits and PRs

## Test plan
- [x] Verified CI workflow change targets the correct file
- [x] Updated documentation is clear and actionable

🤖 Generated with [Claude Code](https://claude.ai/code)