### PR TITLE
Fix Makefile help target error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,5 +70,5 @@ help:
 		| grep -v help \
 		| awk 'BEGIN {FS = ":"}; \
 		{printf "    make $(bold)$(TAB)$(reset)\n", \
-			$$1}'
+			$$1}' || true
 	@echo -e ""


### PR DESCRIPTION
## Summary
- Fixed error when running `make` (default help target)
- Added `|| true` to prevent grep command from causing make to fail when no targets match the pattern

## Test plan
- [x] Run `make` and verify no error is shown
- [x] Verify help output still displays correctly

🤖 Generated with [Claude Code](https://claude.ai/code)