### PR TITLE
Remove unnecessary browser dependencies

### DIFF
--- a/arch/packages-cli
+++ b/arch/packages-cli
@@ -44,10 +44,8 @@ isync
 iwd
 jdk8-openjdk
 kiwix-tools
-libffi7
 libqalculate
 libretro-mesen
-libwebp0.5
 linux
 linux-firmware
 lua51-busted


### PR DESCRIPTION
## Summary
- Remove libffi7 and libwebp0.5 from arch/packages-cli
- These packages were thought to be needed for browser tools but are not required

🤖 Generated with [Claude Code](https://claude.ai/code)