### PR TITLE
Add gitleaks secret scanning integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,14 @@ lint: # Run shellcheck on all shell files
 	@echo "Running shellcheck on shell files.."
 	find . -name "*.sh" -o -path "./river/init" | grep -v ".git" | grep -v "scratch" | xargs shellcheck
 
+check-secret: # Check file or directory for secrets using gitleaks (Usage: make check-secret TARGET=path)
+	@if [ -z "$(TARGET)" ]; then \
+		echo "Usage: make check-secret TARGET=/path/to/file/or/directory"; \
+		exit 1; \
+	fi
+	@echo "Checking $(TARGET) for secrets.."
+	gitleaks dir -v --redact $(TARGET)
+
 # -----------------------------------------------------------
 # CAUTION: If you have a file with the same name as make
 # command, you need to add it to .PHONY below, otherwise it
@@ -74,9 +82,8 @@ reset := $(shell tput sgr0)
 help:
 	@printf '\n'
 	@printf '    $(underline)Available make commands:$(reset)\n\n'
-	@# Print non-check commands with comments
+	@# Print commands with comments
 	@grep -E '^([a-zA-Z0-9_-]+\.?)+:.+#.+$$' $(MAKEFILE_LIST) \
-		| grep -v '^check-' \
 		| grep -v '^env-' \
 		| grep -v '^arg-' \
 		| sed 's/:.*#/: #/g' \

--- a/arch/packages-cli
+++ b/arch/packages-cli
@@ -27,6 +27,7 @@ emulationstation-themes
 eslint
 fastfetch
 github-cli
+gitleaks
 google-gemini-cli
 grub
 haxe


### PR DESCRIPTION
## Summary
- Add gitleaks to arch CLI packages for installation
- Create `make check-secret` target to scan files/directories for secrets  
- Enables checking dotfiles for secrets before adding to repo

## Usage
```bash
make check-secret TARGET=/path/to/file/or/directory
```

## Test plan
- [x] Added gitleaks to arch/packages-cli
- [x] Created make target that accepts TARGET parameter
- [x] Tested with both files and directories
- [x] Verified make help shows the new command
- [x] Fixed PATH variable conflict by using TARGET instead

🤖 Generated with [Claude Code](https://claude.ai/code)