### PR TITLE
Update backup script extension from .zsh to .sh

### DIFF
--- a/nag_runner/nag_runner.arch.json
+++ b/nag_runner/nag_runner.arch.json
@@ -16,7 +16,7 @@
     },
     {
         "name": "backups",
-        "command": "~/Projects/dotfiles/backups.zsh",
+        "command": "~/Projects/dotfiles/backups.sh",
         "interval": "11"
     }
 ]


### PR DESCRIPTION
## Summary
- Updated nag_runner config to reference backups.sh instead of backups.zsh
- Corrects file extension to match actual script type

## Test plan
- [x] Verify nag_runner can find and execute the backup script
- [x] Confirm backup functionality works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)