### PR TITLE
Add pacman cache cleanup and make nag tasks non-interactive

### DIFF
--- a/nag_runner/nag_runner.arch.json
+++ b/nag_runner/nag_runner.arch.json
@@ -1,12 +1,12 @@
 [
     {
         "name": "archlinux updates",
-        "command": "sudo pacman -Syu && yay -Syu",
+        "command": "sudo pacman -Syu --noconfirm && yay -Syu --noconfirm",
         "interval": "7"
     },
     {
-        "name": "prune yay cache",
-        "command": "yay -Sc --aur",
+        "name": "prune package caches",
+        "command": "sudo pacman -Sc --noconfirm && yay -Sc --aur --noconfirm",
         "interval": "31"
     },
     {


### PR DESCRIPTION
## Summary
- Combined pacman and yay cache cleanup into single "prune package caches" task
- Added --noconfirm flags to all pacman and yay commands for non-interactive execution
- Cache cleanup runs every 31 days alongside system updates every 7 days

## Test plan
- [x] Verify nag runner configuration is valid JSON
- [x] Test that pacman and yay commands run without prompting for confirmation
- [x] Confirm cache cleanup task appears in nag runner output

🤖 Generated with [Claude Code](https://claude.ai/code)