### PR TITLE
Fix deprecated foot cursor color configuration

### DIFF
--- a/foot/themes/solarized-light
+++ b/foot/themes/solarized-light
@@ -1,10 +1,8 @@
 # -*- conf -*-
 # Solarized light
 
-[cursor]
-color=fdf6e3 586e75
-
 [colors]
+cursor=fdf6e3 586e75
 background=              fdf6e3
 foreground=              657b83
 regular0=                eee8d5


### PR DESCRIPTION
## Summary
- Fixed deprecated foot cursor color configuration
- Moved cursor color from `[cursor] color=` to `[colors] cursor=` format
- Resolves the deprecation warning: "cursor.color: use colors.cursor instead"

## Test plan
- [x] Verified foot starts without deprecation warning
- [x] Confirmed cursor color still works correctly
- [x] Ran make lint (passed)

🤖 Generated with [Claude Code](https://claude.ai/code)