### PR TITLE
Fix nag_runner interference in river picker shortcuts

### DIFF
--- a/river/init
+++ b/river/init
@@ -29,10 +29,10 @@ done
 riverctl map normal $mod+Shift Return spawn foot
 
 # Mod+P to start the launcher
-riverctl map normal $mod P spawn "foot --app-id float -- zsh -ic $DOTFILES_HOME/river/launcher.sh"
+riverctl map normal $mod P spawn "foot --app-id float -- zsh --no-rcs -c $DOTFILES_HOME/river/launcher.sh"
 
 # Mod+E to start an emoji/unicode picker
-riverctl map normal $mod E spawn "foot --app-id float -- zsh -ic $DOTFILES_HOME/river/emoji.sh"
+riverctl map normal $mod E spawn "foot --app-id float -- zsh --no-rcs -c $DOTFILES_HOME/river/emoji.sh"
 
 # rewrite the above line to show in a smaller window
 # Mod+Q to close the focused view

--- a/waybar/config
+++ b/waybar/config
@@ -13,6 +13,7 @@
 		"clock#3",
 	],
 	"modules-right": [
+		"custom/nag-runner",
 		"custom/network",
 		"pulseaudio",
 		"custom/divider",
@@ -95,6 +96,12 @@
 			"",
 			""
 		]
+	},
+	"custom/nag-runner": {
+		"interval": 30,
+		"exec": "$HOME/Projects/nag-runner/nag_runner.py --check && echo '' || echo '⚠️'",
+		"tooltip": true,
+		"tooltip-format": "Nags Overdue!"
 	},
 	"custom/network": {
 		"interval": 5,


### PR DESCRIPTION
## Summary
- Use `zsh --no-rcs` for alt-p launcher and alt-e emoji picker to prevent nag_runner from interrupting workflow in small picker windows
- Add waybar indicator showing ⚠️ when maintenance tasks are overdue to ensure nags aren't missed

## Test plan
- [x] Test alt-p and alt-e shortcuts no longer show nag_runner prompts
- [x] Verify waybar indicator appears when nags are overdue
- [x] Confirm indicator disappears when all tasks are up to date

🤖 Generated with [Claude Code](https://claude.ai/code)