### PR TITLE
Improve shell command workflow and restore bat usage

### DIFF
--- a/foot/foot.ini
+++ b/foot/foot.ini
@@ -7,3 +7,6 @@ font-bold-italic=MesloLGS Nerd Font Mono:style=Bold Italic:size=11.5
 
 [colors]
 alpha=0.95
+
+[key-bindings]
+show-urls-copy=Control+Shift+l

--- a/zsh/aliases.sh
+++ b/zsh/aliases.sh
@@ -16,8 +16,6 @@ diff --version 2>/dev/null | grep -q GNU && alias diff='diff --color'
 
 # Text viewing
 alias vat="vim -R -c 'set nomodifiable' -c 'nmap q :q!<CR>' -c 'set norelativenumber'"
-alias bat='echo "just use vat"'
-alias batp='echo "just use vat"'
 
 # Python-based aliases
 if command_exists python3; then

--- a/zsh/core.zsh
+++ b/zsh/core.zsh
@@ -9,6 +9,7 @@ mkdir -p ~/.cache/zsh
 export HISTFILE=~/.cache/zsh/history
 export HISTORY_IGNORE="(ls|cd|pwd|exit|cd)*"
 
+setopt AUTOCD                # Change directories without 'cd'
 setopt EXTENDED_HISTORY      # Write the history file in the ':start:elapsed;command' format.
 setopt INC_APPEND_HISTORY    # Write to the history file immediately, not when the shell exits.
 setopt SHARE_HISTORY         # Share history between all sessions.

--- a/zsh/functions.zsh
+++ b/zsh/functions.zsh
@@ -1,10 +1,8 @@
 # LLM code function
 if command_exists llm; then
     llmc() {
-        local clipboard_cmd=$(get_clipboard_copy_cmd)
-        llm --model thinking -s 'code in python (preferred) or zsh (for archlinux, when it seems like a thing that makes a good one liner) unless otherwise specified. Keep it as simple and brief as possible. Output only the code requested, no commentary. Only one example.' --xl "$@" |
-        sed 's/^[[:space:]]*//;s/[[:space:]]*$//' |
-        tee >($clipboard_cmd)
+        local code=$(llm -s 'code in zsh for archlinux. Keep it as simple and brief as possible. Output only the code requested, no commentary. No shebang. Only one example.' --xl "$@" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        print -z "$code"
     }
 fi
 
@@ -46,24 +44,24 @@ if command_exists curl && command_exists llm; then
     q() {
         local url="$1"
         local question="$2"
-        
+
         # Fetch the URL content through Jina
         local content=$(curl -s "https://r.jina.ai/$url")
-        
+
         # Check if the content was retrieved successfully
         if [ -z "$content" ]; then
             echo "Failed to retrieve content from the URL."
             return 1
         fi
-        
+
         system="
         You are a helpful assistant that can answer questions about the content.
         Reply concisely, in a few sentences.
-        
+
         The content:
         ${content}
         "
-        
+
         # Use llm with the fetched content as a system prompt
         llm prompt "$question" -s "$system"
     }
@@ -74,11 +72,11 @@ if command_exists yt-dlp && command_exists curl && command_exists llm; then
     qv() {
         local url="$1"
         local question="$2"
-        
+
         # Fetch the URL content through Jina
         local subtitle_url=$(yt-dlp -q --skip-download --convert-subs srt --write-sub --sub-langs "en" --write-auto-sub --print "requested_subtitles.en.url" "$url")
         local content=$(curl -s "$subtitle_url" | sed '/^$/d' | grep -v '^[0-9]*$' | grep -v '\-->' | sed 's/<[^>]*>//g' | tr '\n' ' ')
-        
+
         # Check if the content was retrieved successfully
         if [ -z "$content" ]; then
             echo "Failed to retrieve content from the URL."
@@ -87,3 +85,6 @@ if command_exists yt-dlp && command_exists curl && command_exists llm; then
     }
 fi
 
+function -() {
+    cd -
+}


### PR DESCRIPTION
## Summary
- Update llmc function to use print -z to insert generated code directly into command line buffer instead of clipboard
- Add foot key binding for URL copy mode (Ctrl+Shift+l)
- Enable autocd option for directory navigation without 'cd' command
- Add '-' function for quick directory switching
- Remove bat/batp aliases to restore native bat command usage
- Clean up whitespace and formatting inconsistencies

## Test plan
- [x] Test llmc function generates code and inserts into command line
- [x] Verify autocd works for directory navigation
- [x] Test '-' function for directory switching
- [x] Confirm bat commands work natively
- [x] Test foot URL copy binding

🤖 Generated with [Claude Code](https://claude.ai/code)