### PR TITLE
Migrate zsh plugins to prefer pacman packages

### DIFF
--- a/arch/packages-cli
+++ b/arch/packages-cli
@@ -105,3 +105,5 @@ xq
 yamllint
 yt-dlp
 zram-generator
+zsh-autosuggestions
+zsh-syntax-highlighting

--- a/zsh/plugins.zsh
+++ b/zsh/plugins.zsh
@@ -1,11 +1,33 @@
-# Zsh syntax highlighting
-source_if_exists $HOME/.zsh/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
-if [[ -f $HOME/.zsh/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh ]]; then
+# Zsh syntax highlighting - prefer pacman install, fallback to manual
+if [[ -f /usr/share/zsh/plugins/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh ]]; then
+    source /usr/share/zsh/plugins/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
     ZSH_HIGHLIGHT_STYLES[comment]='fg=blue'
+elif [[ -f $HOME/.zsh/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh ]]; then
+    source $HOME/.zsh/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+    ZSH_HIGHLIGHT_STYLES[comment]='fg=blue'
+else
+    # Auto-install if git is available and directory doesn't exist
+    if command_exists git && [[ ! -d $HOME/.zsh/zsh-syntax-highlighting ]]; then
+        mkdir -p $HOME/.zsh
+        git clone https://github.com/zsh-users/zsh-syntax-highlighting.git $HOME/.zsh/zsh-syntax-highlighting
+        source $HOME/.zsh/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+        ZSH_HIGHLIGHT_STYLES[comment]='fg=blue'
+    fi
 fi
 
-# Zsh autosuggestions
-source_if_exists $HOME/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh
+# Zsh autosuggestions - prefer pacman install, fallback to manual
+if [[ -f /usr/share/zsh/plugins/zsh-autosuggestions/zsh-autosuggestions.zsh ]]; then
+    source /usr/share/zsh/plugins/zsh-autosuggestions/zsh-autosuggestions.zsh
+elif [[ -f $HOME/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh ]]; then
+    source $HOME/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh
+else
+    # Auto-install if git is available and directory doesn't exist
+    if command_exists git && [[ ! -d $HOME/.zsh/zsh-autosuggestions ]]; then
+        mkdir -p $HOME/.zsh
+        git clone https://github.com/zsh-users/zsh-autosuggestions.git $HOME/.zsh/zsh-autosuggestions
+        source $HOME/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh
+    fi
+fi
 
 # FZF integration
 if command_exists fzf; then


### PR DESCRIPTION
## Summary
- Update plugins.zsh to check pacman paths first (/usr/share/zsh/plugins/)
- Fallback to manual installs (~/.zsh/) for cross-platform portability
- Auto-install from git as final fallback if neither exists
- Add zsh-autosuggestions and zsh-syntax-highlighting to arch packages

## Test plan
- [x] Verified plugins load from pacman paths after installation
- [x] Confirmed fallback behavior works on other systems
- [x] Added packages to arch/packages-cli for consistency

This maintains compatibility across different systems while preferring the official Arch packages when available.

🤖 Generated with [Claude Code](https://claude.ai/code)