### PR TITLE
Fix Python help package-to-import name mapping

### DIFF
--- a/zsh/functions.zsh
+++ b/zsh/functions.zsh
@@ -149,7 +149,10 @@ python_help() {
                     fi
                     ;;
                 *"Module docs"*)
-                    python -m pydoc "$target" 2>/dev/null || { command_exists uv && uv run --with "$package_spec" python -m pydoc "$target"; }
+                    # Try to get the correct import name first
+                    local import_name
+                    import_name=$(python "$script_path" "$target" --get-import-name 2>/dev/null) || import_name="$target"
+                    python -m pydoc "$import_name" 2>/dev/null || { command_exists uv && uv run --with "$package_spec" python -m pydoc "$import_name"; }
                     ;;
                 *"Browse items"*)
                     local selected

--- a/zsh/python_help.py
+++ b/zsh/python_help.py
@@ -2,11 +2,38 @@
 import sys
 import importlib
 import pkgutil
+try:
+    import importlib.metadata
+except ImportError:
+    import importlib_metadata as importlib_metadata
+
+def get_import_name(package_name):
+    """Get the import name for a package name."""
+    try:
+        # Get mapping of top-level modules to distributions
+        packages = importlib.metadata.packages_distributions()
+        # Reverse it to get package -> import mapping
+        for module, distributions in packages.items():
+            if package_name in distributions:
+                return module
+    except:
+        pass
+    
+    # Fallback: try the package name as-is
+    return package_name
+
+def import_module_smart(module_name):
+    """Import module, handling package name to import name mapping."""
+    try:
+        return importlib.import_module(module_name)
+    except ImportError:
+        import_name = get_import_name(module_name)
+        return importlib.import_module(import_name)
 
 def get_module_items(module_name):
     """Get categorized items from a module."""
     try:
-        module = importlib.import_module(module_name)
+        module = import_module_smart(module_name)
         items = [x for x in dir(module) if not x.startswith('_')]
         
         classes = []
@@ -94,7 +121,7 @@ def show_object_help(module_name, object_name):
             pass
         
         # If that fails, try as an attribute of the module
-        module = importlib.import_module(module_name)
+        module = import_module_smart(module_name)
         obj = getattr(module, object_name)
         help(obj)
     except (ImportError, AttributeError) as e:
@@ -103,13 +130,15 @@ def show_object_help(module_name, object_name):
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
-        print("Usage: python_help.py <module> [--fzf|--summary] or <module.object>")
+        print("Usage: python_help.py <module> [--fzf|--summary|--get-import-name] or <module.object>")
         sys.exit(1)
     
     target = sys.argv[1]
     mode = sys.argv[2] if len(sys.argv) > 2 else None
     
-    if '.' in target:
+    if mode == '--get-import-name':
+        print(get_import_name(target))
+    elif '.' in target:
         module_name, object_name = target.split('.', 1)
         show_object_help(module_name, object_name)
     elif mode == '--fzf':

--- a/zsh/python_help.py
+++ b/zsh/python_help.py
@@ -9,15 +9,19 @@ except ImportError:
 
 def get_import_name(package_name):
     """Get the import name for a package name."""
-    try:
-        # Get mapping of top-level modules to distributions
-        packages = importlib.metadata.packages_distributions()
-        # Reverse it to get package -> import mapping
-        for module, distributions in packages.items():
-            if package_name in distributions:
-                return module
-    except:
-        pass
+    # Get mapping of top-level modules to distributions
+    packages = importlib.metadata.packages_distributions()
+    # Find all modules for this package
+    matches = []
+    for module, distributions in packages.items():
+        # Case-insensitive comparison for distribution names
+        if package_name.lower() in [d.lower() for d in distributions]:
+            matches.append(module)
+    
+    if matches:
+        # Prefer public modules (no underscore prefix)
+        public_matches = [m for m in matches if not m.startswith('_')]
+        return public_matches[0] if public_matches else matches[0]
     
     # Fallback: try the package name as-is
     return package_name


### PR DESCRIPTION
## Summary
- Adds automatic package name to import name resolution using importlib.metadata
- Supports packages where package name ≠ import name (beautifulsoup4 → bs4, pillow → PIL, etc.)
- Refactors duplicate import logic into reusable import_module_smart() helper function
- Fixes module docs option to use correct import names for pydoc

## Test plan
- [x] Test package name mapping: `help python beautifulsoup4` works for all options
- [x] Test regular packages still work: `help python requests` unchanged
- [x] Test built-in modules: `help python unittest` unchanged  
- [x] Test all three help options (summary/docs/browse) work with mapped names
- [x] Test refactored code maintains same functionality
- [x] Verify no regression in existing help functionality

🤖 Generated with [Claude Code](https://claude.ai/code)