### PR TITLE
Add document picker with frequency-based sorting

### DIFF
--- a/river/document_launcher.sh
+++ b/river/document_launcher.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -e
+
+# Build list of documents from both directories if they exist
+documents=""
+
+if [ -d "$HOME/Documents" ]; then
+    documents=$(find "$HOME/Documents" -type f 2>/dev/null)
+fi
+
+if [ -d "$HOME/nextcloud/Documents" ]; then
+    nextcloud_docs=$(find "$HOME/nextcloud/Documents" -type f 2>/dev/null)
+    if [ -n "$documents" ]; then
+        documents="$documents"$'\n'"$nextcloud_docs"
+    else
+        documents="$nextcloud_docs"
+    fi
+fi
+
+# Exit if no documents found
+if [ -z "$documents" ]; then
+    exit 1
+fi
+
+# Ensure history file exists
+touch "$HOME/.cache/document_history"
+
+# Get documents we've previously opened, excluding any that don't exist anymore
+documents_from_history=$(grep -xFf <(echo -e "$documents") "$HOME/.cache/document_history" 2>/dev/null || true)
+
+# Make a list of all documents, sorted by frequency they've been opened via this picker
+frequency_sorted_documents=$(echo -e "$documents\n$documents_from_history" | sort | uniq -c | sort -nr | awk '{print $2}')
+
+document_picked=$(echo -e "$frequency_sorted_documents" | sed "s|$HOME|~|g" | fzf | sed "s|~|$HOME|g")
+
+# Exit if nothing selected
+[ -z "$document_picked" ] && exit 1
+
+# Save the selected document to history
+echo "$document_picked" >> "$HOME/.cache/document_history"
+
+# Open the selected document with xdg-open via riverctl spawn
+riverctl spawn "xdg-open \"$document_picked\""

--- a/river/init
+++ b/river/init
@@ -34,6 +34,9 @@ riverctl map normal $mod P spawn "foot --app-id float -- zsh --no-rcs -c $DOTFIL
 # Mod+E to start an emoji/unicode picker
 riverctl map normal $mod E spawn "foot --app-id float -- zsh --no-rcs -c $DOTFILES_HOME/river/emoji.sh"
 
+# Mod+D to start the document picker
+riverctl map normal $mod D spawn "foot --app-id float -- zsh --no-rcs -c $DOTFILES_HOME/river/document_launcher.sh"
+
 # rewrite the above line to show in a smaller window
 # Mod+Q to close the focused view
 riverctl map normal $mod Q close


### PR DESCRIPTION
## Summary
- Adds a new document picker accessible via Mod+D in river
- Searches both ~/Documents and ~/nextcloud/Documents directories
- Implements frequency-based sorting using a history file to prioritize recently used documents
- Uses fzf for interactive selection with tilde paths for better screen space usage
- Integrates seamlessly with river window manager via riverctl spawn

## Test plan
- [ ] Test Mod+D keybinding launches the document picker
- [ ] Verify documents from both directories are found
- [ ] Confirm frequency-based sorting works with repeated usage
- [ ] Check that tilde paths display correctly in fzf
- [ ] Ensure selected documents open properly with xdg-open

🤖 Generated with [Claude Code](https://claude.ai/code)