### PR TITLE
Add automatic monitor hotplug detection for River

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -64,6 +64,7 @@ else # Assume Arch or derivatives
     "$DOTFILES_HOME"/river/setup.sh
     "$DOTFILES_HOME"/foot/setup.sh
     "$DOTFILES_HOME"/font/setup.sh
+    "$DOTFILES_HOME"/systemd/setup.sh
   fi
   
   "$DOTFILES_HOME"/git/setup.sh

--- a/river/init
+++ b/river/init
@@ -183,15 +183,7 @@ riverctl spawn udiskie
 riverctl spawn 'swayidle -w before-sleep "swaylock -c 000033"'
 export QT_QPA_PLATFORM="wayland"
 
-[ -n "$HIDPI" ] && wlr-randr --output eDP-1 --scale 1.75
-
-# Configure second monitor scaling and position
-if wlr-randr | grep -q "HDMI-A-1"; then
-    wlr-randr --output HDMI-A-1 --scale 1.75 --pos 0,0
-    wlr-randr --output eDP-1 --pos 2194,0
-else
-    wlr-randr --output eDP-1 --pos 0,0
-fi
+riverctl spawn "$DOTFILES_HOME/river/monitor-setup.sh"
 
 # share wayland vars with systemd. This is needed to make screensharing work
 export XDG_CURRENT_DESKTOP=wlr

--- a/river/monitor-setup.sh
+++ b/river/monitor-setup.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 # Monitor configuration for River window manager
 
 LOGFILE="$HOME/.local/share/monitor-hotplug.log"

--- a/river/monitor-setup.sh
+++ b/river/monitor-setup.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Monitor configuration for River window manager
+
+LOGFILE="$HOME/.local/share/monitor-hotplug.log"
+mkdir -p "$(dirname "$LOGFILE")"
+
+log() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" >> "$LOGFILE"
+}
+
+log "Monitor setup triggered"
+
+# Apply HiDPI scaling if HIDPI environment variable is set
+if [ -n "$HIDPI" ]; then
+    log "Applying HiDPI scaling to eDP-1"
+    wlr-randr --output eDP-1 --scale 1.75
+fi
+
+# Configure second monitor scaling and position
+if wlr-randr | grep -q "HDMI-A-1"; then
+    log "HDMI-A-1 detected, configuring dual monitor setup"
+    wlr-randr --output HDMI-A-1 --scale 1.75 --pos 0,0
+    wlr-randr --output eDP-1 --pos 2194,0
+else
+    log "No HDMI-A-1 detected, configuring single monitor setup"
+    wlr-randr --output eDP-1 --pos 0,0
+fi
+
+log "Monitor setup completed"

--- a/systemd/setup.sh
+++ b/systemd/setup.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 # Create systemd user config directory
 mkdir -p "$HOME/.config/systemd/user"

--- a/systemd/setup.sh
+++ b/systemd/setup.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# Create systemd user config directory
+mkdir -p "$HOME/.config/systemd/user"
+
+# Symlink systemd user services
+ln -svf "$DOTFILES_HOME/systemd/user/monitor-hotplug.service" "$HOME/.config/systemd/user/monitor-hotplug.service"
+
+# Reload systemd and enable service
+systemctl --user daemon-reload
+systemctl --user enable monitor-hotplug.service
+
+# Start service if not already running
+systemctl --user is-active --quiet monitor-hotplug.service || systemctl --user start monitor-hotplug.service

--- a/systemd/user/monitor-hotplug-daemon.sh
+++ b/systemd/user/monitor-hotplug-daemon.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Monitor hotplug daemon - polls DRM status files for changes
+
+# Set DOTFILES_HOME if not already set
+DOTFILES_HOME="${DOTFILES_HOME:-$HOME/Projects/dotfiles}"
+
+prev=$(cat /sys/class/drm/*/status 2>/dev/null | sort)
+while true; do
+    sleep 2
+    curr=$(cat /sys/class/drm/*/status 2>/dev/null | sort)
+    if [ "$curr" != "$prev" ]; then
+        "$DOTFILES_HOME/river/monitor-setup.sh"
+    fi
+    prev="$curr"
+done

--- a/systemd/user/monitor-hotplug-daemon.sh
+++ b/systemd/user/monitor-hotplug-daemon.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 # Monitor hotplug daemon - polls DRM status files for changes
 
 # Set DOTFILES_HOME if not already set

--- a/systemd/user/monitor-hotplug.service
+++ b/systemd/user/monitor-hotplug.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Monitor hotplug handler
+After=graphical-session.target
+
+[Service]
+ExecStart=/bin/sh -c 'prev=$(cat /sys/class/drm/*/status 2>/dev/null | sort); while true; do sleep 2; curr=$(cat /sys/class/drm/*/status 2>/dev/null | sort); [ "$curr" != "$prev" ] && %h/Projects/dotfiles/river/monitor-setup.sh; prev="$curr"; done'
+Restart=always
+RestartSec=1
+
+[Install]
+WantedBy=default.target

--- a/systemd/user/monitor-hotplug.service
+++ b/systemd/user/monitor-hotplug.service
@@ -3,7 +3,7 @@ Description=Monitor hotplug handler
 After=graphical-session.target
 
 [Service]
-ExecStart=/bin/sh -c 'prev=$(cat /sys/class/drm/*/status 2>/dev/null | sort); while true; do sleep 2; curr=$(cat /sys/class/drm/*/status 2>/dev/null | sort); [ "$curr" != "$prev" ] && %h/Projects/dotfiles/river/monitor-setup.sh; prev="$curr"; done'
+ExecStart=%h/Projects/dotfiles/systemd/user/monitor-hotplug-daemon.sh
 Restart=always
 RestartSec=1
 


### PR DESCRIPTION
## Summary
- Extract monitor configuration from river/init to separate monitor-setup.sh script
- Add systemd user service for automatic monitor hotplug detection  
- Automatically reconfigure displays when monitors are connected/disconnected
- Integrate systemd service setup into dotfiles installation process

## Technical Details
- Uses polling approach (every 2 seconds) to monitor DRM status files in /sys/class/drm/*/status
- Falls back from inotify since sysfs files don't trigger filesystem events
- Service runs in user context with proper Wayland environment variables
- Idempotent setup script that can be run multiple times safely

## Test plan
- [x] Service detects monitor plug/unplug events and logs them
- [x] Display configuration automatically updates on hotplug
- [x] Setup script integrates with dotfiles install process
- [x] Shellcheck linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)