### PR TITLE
Replace firefox with zen-browser-bin in Arch packages

### DIFF
--- a/arch/packages-gui
+++ b/arch/packages-gui
@@ -5,7 +5,6 @@ discord
 dosbox
 emulationstation
 fceux
-firefox
 fluidsynth
 foot
 gimp
@@ -41,3 +40,4 @@ wayfire
 wl-clipboard
 xdg-desktop-portal-gtk
 xdg-desktop-portal-wlr
+zen-browser-bin


### PR DESCRIPTION
## Summary
- Replace firefox with zen-browser-bin in arch/packages-gui
- Sort the packages file alphabetically to maintain organization

## Test plan
- [ ] Verify zen-browser-bin is available in AUR
- [ ] Test package installation on Arch system
- [ ] Confirm sorted order is maintained

🤖 Generated with [Claude Code](https://claude.ai/code)