### PR TITLE
Add click to disconnect for waybar controller module

### DIFF
--- a/waybar/config
+++ b/waybar/config
@@ -110,7 +110,8 @@
 		"exec": "$HOME/Projects/dotfiles/waybar/controller_status.sh",
 		"tooltip": false,
 		"format": "{}",
-		"return-type": "text"
+		"return-type": "text",
+		"on-click": "bluetoothctl disconnect 64:B5:C6:3E:91:54"
 	},
 	"custom/network": {
 		"interval": 5,


### PR DESCRIPTION
## Summary
- Added click action to Nintendo Switch Pro Controller status in waybar
- Users can now click the controller icon to disconnect it via Bluetooth
- Improves user experience by providing quick disconnect functionality

## Test plan
- [ ] Verify waybar config syntax is valid
- [ ] Test that clicking controller status disconnects the controller
- [ ] Confirm CI tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)