### PR TITLE
Add tooltip to waybar controller module

### DIFF
--- a/waybar/config
+++ b/waybar/config
@@ -108,7 +108,8 @@
 	"custom/controller": {
 		"interval": 10,
 		"exec": "$HOME/Projects/dotfiles/waybar/controller_status.sh",
-		"tooltip": false,
+		"tooltip": true,
+		"tooltip-format": "Click to disconnect",
 		"format": "{}",
 		"return-type": "text",
 		"on-click": "bluetoothctl disconnect 64:B5:C6:3E:91:54"


### PR DESCRIPTION
## Summary
- Added "Click to disconnect" tooltip to Nintendo Switch Pro Controller status in waybar
- Provides clear user feedback about the click functionality
- Enhances user experience by indicating the controller status is interactive

## Test plan
- [ ] Verify waybar config syntax is valid
- [ ] Test that hovering shows "Click to disconnect" tooltip
- [ ] Confirm CI tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)