### PR TITLE
Add macOS keyboard shortcuts configuration

### DIFF
--- a/mac/DefaultKeyBinding.dict
+++ b/mac/DefaultKeyBinding.dict
@@ -1,0 +1,7 @@
+{
+    /* Ctrl + Left/Right Arrow to jump words */
+    "^\UF702" = "moveWordLeft:";
+    "^\UF703" = "moveWordRight:";
+    "^$\UF702" = "moveWordLeftAndModifySelection:";
+    "^$\UF703" = "moveWordRightAndModifySelection:";
+}

--- a/mac/install.sh
+++ b/mac/install.sh
@@ -8,5 +8,6 @@ if [ -n "$missing_packages" ]; then
   done
 fi
 
+"$DOTFILES_HOME"/mac/setup.sh
 "$DOTFILES_HOME"/git/setup.sh
 "$DOTFILES_HOME"/tmux/setup.sh

--- a/mac/setup.sh
+++ b/mac/setup.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -e
+
+# Helper function to disable a symbolic hotkey
+disable_hotkey() {
+  local hotkey_id=$1
+  defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add "$hotkey_id" "
+  <dict>
+    <key>enabled</key><false/>
+  </dict>
+"
+}
+
+# Remap Caps Lock to Control
+# HID usage codes: 30064771296 = Caps Lock, 30064771129 = Control
+KEYBOARD_ID="5426-269-0"
+if system_profiler SPUSBDataType 2>/dev/null | grep -q "$KEYBOARD_ID" || \
+   defaults -currentHost read -g 2>/dev/null | grep -q "com.apple.keyboard.modifiermapping.$KEYBOARD_ID"; then
+  defaults -currentHost write -g com.apple.keyboard.modifiermapping.$KEYBOARD_ID -array-add '
+<dict>
+  <key>HIDKeyboardModifierMappingDst</key>
+  <integer>30064771129</integer>
+  <key>HIDKeyboardModifierMappingSrc</key>
+  <integer>30064771296</integer>
+</dict>
+'
+else
+  echo "Warning: Keyboard $KEYBOARD_ID not found. Caps Lock mapping not applied." >&2
+  echo "Run this to find your keyboard ID:" >&2
+  echo "  defaults -currentHost read -g | grep -i keyboard" >&2
+fi
+
+# Disable Ctrl+Space keyboard layout switching (conflicts with tmux prefix key)
+# 60 = Select the previous input source
+# 61 = Select next source in Input menu
+disable_hotkey 60
+disable_hotkey 61
+
+# Disable Mission Control Ctrl+Arrow shortcuts to allow word jumping
+# 79 = Move left a space (Ctrl+Left Arrow)
+# 81 = Move right a space (Ctrl+Right Arrow)
+disable_hotkey 79
+disable_hotkey 81
+
+# Create DefaultKeyBinding.dict symlink for Ctrl+Arrow word jumping
+mkdir -p ~/Library/KeyBindings
+ln -svf "$DOTFILES_HOME/mac/DefaultKeyBinding.dict" ~/Library/KeyBindings/DefaultKeyBinding.dict
+
+# Restart preferences daemon to apply changes
+/System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings -u


### PR DESCRIPTION
## Summary
- Add `mac/setup.sh` to programmatically configure macOS keyboard shortcuts
- Disable Ctrl+Space input source switching (conflicts with tmux prefix key)
- Disable Mission Control Ctrl+Arrow shortcuts (enables Ctrl+Arrow word jumping)
- Remap Caps Lock to Control via keyboard modifier mapping with detection/warning
- Add `DefaultKeyBinding.dict` for native Ctrl+Arrow word navigation in macOS apps

## Test plan
- [x] Run `mac/setup.sh` and verify it completes without errors
- [x] Verify Ctrl+Space works in tmux without triggering input source switching
- [x] Verify Ctrl+Left/Right arrows jump words in Finder, Terminal, and other apps
- [x] Verify Mission Control shortcuts are disabled in System Settings
- [x] Verify keyboard detection works and provides helpful warning if ID not found

🤖 Generated with [Claude Code](https://claude.com/claude-code)