### PR TITLE
Add kiwix-tools build dependencies and documentation

### DIFF
--- a/docs/kiwix.md
+++ b/docs/kiwix.md
@@ -1,0 +1,34 @@
+# Kiwix Server Setup
+
+Kiwix server is not available via Homebrew for Apple Silicon, so we build from source.
+
+## Building from Source
+
+```bash
+# Clone repos
+mkdir -p ~/src
+cd ~/src
+git clone https://github.com/kiwix/kiwix-build
+git clone https://github.com/kiwix/kiwix-tools
+
+# Install kiwix-build in virtualenv
+cd kiwix-build
+python3 -m venv venv
+source venv/bin/activate
+pip install .
+
+# Build kiwix-tools (includes kiwix-serve)
+kiwix-build kiwix-tools
+
+# Copy binary to PATH
+cp ~/src/kiwix-build/BUILD_native_dyn/INSTALL/bin/kiwix-serve ~/.local/bin/
+```
+
+## Running
+
+```bash
+# Download ZIM file to ~/kiwix/
+kiwix-serve --port 8080 ~/kiwix/yourfile.zim
+```
+
+Access at http://localhost:8080

--- a/mac/packages
+++ b/mac/packages
@@ -32,9 +32,11 @@ keepassxc
 kitty
 libqalculate
 libreoffice
+libzim
 lsd
 lua-language-server
 luarocks
+meson
 moreutils
 mpv
 msmtp
@@ -42,11 +44,13 @@ mypy
 nasm
 ncurses
 neovim
+ninja
 nmap
 node
 ollama
 openvpn
 pandoc
+pkgconf
 prettier
 pylint
 pyright


### PR DESCRIPTION
## Summary
- Add build dependencies (libzim, meson, ninja, pkgconf) to mac/packages
- Add docs/kiwix.md with instructions for building kiwix-tools from source on Apple Silicon
- Kiwix server is not available via Homebrew for Apple Silicon, requires building from source

## Test plan
- [x] Verified build dependencies install correctly
- [x] Successfully built kiwix-serve from source
- [x] Documented build process in docs/kiwix.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)