### PR TITLE
Move lmstudio PATH to core.zsh and ignore logs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ QtProject.conf
 CLAUDE.local.md
 scratch/
 whisper/.venv/
+logs/

--- a/zsh/core.zsh
+++ b/zsh/core.zsh
@@ -1,5 +1,5 @@
 # PATH
-export PATH=$PATH:$HOME/.local/bin:$HOME/.claude/local
+export PATH=$PATH:$HOME/.local/bin:$HOME/.claude/local:$HOME/.lmstudio/bin
 
 # History settings
 export HISTSIZE=100000

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -36,4 +36,3 @@ if [[ "$PROFILE_STARTUP" == true ]]; then
     unsetopt xtrace
     exec 2>&3 3>&-
 fi
-


### PR DESCRIPTION
## Summary
- Moved lmstudio PATH configuration from zshrc to core.zsh where other PATH modifications live
- Removed auto-generated lmstudio comments from zshrc
- Added logs/ directory to .gitignore to prevent runtime logs from being tracked
- Removed leftover kiwix plist file that was already installed in ~/Library/LaunchAgents/

## Test plan
- [ ] Verify zsh still loads correctly
- [ ] Verify lmstudio CLI is still in PATH
- [ ] Verify logs/ directory is ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)