### PR TITLE
Add cross-platform clipboard integration for tmux

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -41,11 +41,41 @@ setw -g aggressive-resize on
 # Use vi mode in copy mode
 setw -g mode-keys vi
 
+# Platform-specific clipboard integration
+# Detect OS and set appropriate clipboard commands
+if-shell "uname -s | grep -q Darwin" \
+    "set -g @copy-command 'pbcopy'" \
+    "set -g @copy-command 'wl-copy'"
+
+if-shell "uname -s | grep -q Darwin" \
+    "set -g @paste-command 'pbpaste'" \
+    "set -g @paste-command 'wl-paste'"
+
+# Mouse wheel scrolling - works in copy mode and normal mode
+bind -n WheelUpPane if-shell -F -t = "#{mouse_any_flag}" "send-keys -M" "if -Ft= '#{pane_in_mode}' 'send-keys -M' 'select-pane -t=; copy-mode -e; send-keys -M'"
+bind -n WheelDownPane select-pane -t= \; send-keys -M
+bind -n C-WheelUpPane select-pane -t= \; copy-mode -e \; send-keys -M
+bind -T copy-mode-vi C-WheelUpPane send-keys -X halfpage-up
+bind -T copy-mode-vi C-WheelDownPane send-keys -X halfpage-down
+
 # Vi-style copy mode key bindings
 bind-key -T copy-mode-vi v send-keys -X begin-selection
 bind-key -T copy-mode-vi V send-keys -X select-line
 bind-key -T copy-mode-vi C-v send-keys -X rectangle-toggle
-bind-key -T copy-mode-vi y send-keys -X copy-selection-and-cancel
+
+# Clipboard integration for vi copy mode
+# On Linux (Wayland), use wl-copy; on macOS, use pbcopy
+if-shell "uname -s | grep -q Darwin" \
+    "bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel 'pbcopy'" \
+    "bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel 'wl-copy'"
+
+if-shell "uname -s | grep -q Darwin" \
+    "bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel 'pbcopy'" \
+    "bind-key -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel 'wl-copy'"
+
+if-shell "uname -s | grep -q Darwin" \
+    "bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel 'pbcopy'" \
+    "bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel 'wl-copy'"
 
 # Vim-style pane splitting
 bind s split-window -v    # horizontal split (like vim Ctrl+w s)


### PR DESCRIPTION
## Summary
- Added cross-platform clipboard integration that works on both Linux (Wayland) and macOS
- Enabled mouse wheel scrolling in tmux with automatic copy mode entry
- Implemented three convenient ways to copy text to system clipboard

## Changes
- Platform detection: automatically uses `wl-copy` on Linux or `pbcopy` on macOS
- Mouse wheel scrolling: scroll up/down in panes, Ctrl+wheel for half-page scrolling in copy mode
- Clipboard integration via:
  - Mouse drag and release (automatic copy on release)
  - Vi-mode `y` key (visual select then copy)
  - Enter key in copy mode

## Test plan
- [x] Configuration passes `make lint`
- [ ] Test on Linux with wl-copy: mouse drag, `y` key, Enter key all copy to clipboard
- [ ] Test on macOS with pbcopy: mouse drag, `y` key, Enter key all copy to clipboard
- [ ] Verify mouse wheel scrolling works in both normal and copy mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)