### PR TITLE
Fix foot deprecation warnings after update

### DIFF
--- a/darkman/theme-functions.sh
+++ b/darkman/theme-functions.sh
@@ -43,11 +43,11 @@ set_foot_theme() {
     local signal=$2
     local theme_config="$HOME/.local/share/foot/foot-theme.ini"
 
-    # Update initial-color-theme setting (1=dark/colors, 2=light/colors2)
+    # Update initial-color-theme setting
     if [[ "$mode" == "dark" ]]; then
-        echo "initial-color-theme=1" > "$theme_config"
+        echo "initial-color-theme=dark" > "$theme_config"
     else
-        echo "initial-color-theme=2" > "$theme_config"
+        echo "initial-color-theme=light" > "$theme_config"
     fi
 
     # Signal all running foot instances to reload config

--- a/foot/foot.ini
+++ b/foot/foot.ini
@@ -5,7 +5,7 @@ font-bold=MesloLGS Nerd Font Mono:style=Bold:size=11.5
 font-italic=MesloLGS Nerd Font Mono:style=Italic:size=11.5
 font-bold-italic=MesloLGS Nerd Font Mono:style=Bold Italic:size=11.5
 
-[colors]
+[colors-dark]
 # Dark theme (solarized-dark) - used when initial-color-theme=1
 alpha=0.95
 cursor= 002b36 93a1a1
@@ -28,7 +28,7 @@ bright5=    6c71c4
 bright6=    93a1a1
 bright7=    fdf6e3
 
-[colors2]
+[colors-light]
 # Light theme (solarized-light) - used when initial-color-theme=2
 alpha=0.95
 cursor=fdf6e3 586e75

--- a/foot/setup.sh
+++ b/foot/setup.sh
@@ -7,5 +7,5 @@ ln -svnf "$DOTFILES_HOME/foot/themes/" "$HOME/.local/share/foot/themes"
 # Create default theme config (dark mode) in case darkman hasn't run yet
 if [ ! -f "$HOME/.local/share/foot/foot-theme.ini" ]; then
     echo "# Foot theme setting - managed by darkman, not in source control" > "$HOME/.local/share/foot/foot-theme.ini"
-    echo "initial-color-theme=1" >> "$HOME/.local/share/foot/foot-theme.ini"
+    echo "initial-color-theme=dark" >> "$HOME/.local/share/foot/foot-theme.ini"
 fi


### PR DESCRIPTION
## Summary
- Rename `[colors]` to `[colors-dark]` and `[colors2]` to `[colors-light]` in foot.ini
- Change `initial-color-theme` values from numeric (`1`/`2`) to string (`dark`/`light`) in setup.sh and darkman/theme-functions.sh
- Resolves deprecation warnings introduced in latest foot update

## Test plan
- [ ] Open a new foot terminal and verify no deprecation warnings appear
- [ ] Test dark/light theme switching via darkman
- [ ] Verify colors display correctly in both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)