### PR TITLE
Change chawan image-mode from sixel to auto

### DIFF
--- a/chawan/config.toml
+++ b/chawan/config.toml
@@ -19,7 +19,7 @@ meta-refresh = "always"
 
 [display]
 # Set image display mode (auto, sixel, or kitty)
-image-mode = "sixel"
+image-mode = "auto"
 
 # Custom search engine using just-bangs-lite
 [[omnirule]]


### PR DESCRIPTION
## Summary
- Change chawan `image-mode` from `"sixel"` to `"auto"` so it selects the best available image display method for the current terminal

## Test plan
- [ ] Verify chawan renders images correctly in different terminal emulators

🤖 Generated with [Claude Code](https://claude.com/claude-code)