### PR TITLE
Update chawan with inline images and clipboard

### DIFF
--- a/chawan/auto.mailcap
+++ b/chawan/auto.mailcap
@@ -1,3 +1,3 @@
 # Chawan auto-executed mailcap entries
 # Images
-image/*; imv-mailcap %u
+image/*; exec "$CHA_LIBEXEC_DIR"/img2html '%t' '%u'; x-htmloutput; x-needsimage

--- a/chawan/config.toml
+++ b/chawan/config.toml
@@ -17,6 +17,10 @@ referer-from = true
 # Auto-accept redirects without confirmation
 meta-refresh = "always"
 
+[external]
+copy-cmd = "wl-copy"
+paste-cmd = "wl-paste"
+
 [display]
 # Set image display mode (auto, sixel, or kitty)
 image-mode = "auto"


### PR DESCRIPTION
## Summary
- Switch mailcap image handler from `imv-mailcap` to chawan's built-in `img2html` for inline image display
- Add `[external]` section with `wl-copy`/`wl-paste` for Wayland clipboard integration

## Test plan
- [ ] Open an image in chawan and verify inline rendering
- [ ] Copy/paste text in chawan and verify clipboard works with Wayland

🤖 Generated with [Claude Code](https://claude.com/claude-code)