### PR TITLE
Add package cooldown periods for npm and uv

### DIFF
--- a/nag_runner/nag_runner.arch.json
+++ b/nag_runner/nag_runner.arch.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "system package updates",
-        "command": "yay -Syu --noconfirm && npm update -g && uv tool upgrade --all",
+        "command": "yay -Syu --noconfirm && npm update -g --min-release-age 7 && uv tool upgrade --all --exclude-newer '1 week'",
         "interval": "7"
     },
     {

--- a/zsh/core.zsh
+++ b/zsh/core.zsh
@@ -27,6 +27,7 @@ setopt HIST_REDUCE_BLANKS    # Remove superfluous blanks from each command line 
 export DOTFILES_HOME=$HOME/Projects/dotfiles
 export GPG_TTY=$TTY
 export PYTHONPATH=.
+export UV_EXCLUDE_NEWER="1 week"
 
 # Platform-specific environment setup
 if command_exists nvim; then


### PR DESCRIPTION
## Summary
- Add 1-week cooldown to `uv tool upgrade` via `--exclude-newer '1 week'` in nag runner
- Add 1-week cooldown to `npm update -g` via `--min-release-age 7` in nag runner
- Set `UV_EXCLUDE_NEWER="1 week"` globally in shell environment for all uv operations

## Test plan
- [ ] Source zshrc and verify `echo $UV_EXCLUDE_NEWER` outputs "1 week"
- [ ] Run `uv tool upgrade --all --exclude-newer '1 week'` and confirm it works
- [ ] Run `npm update -g --min-release-age 7` and confirm it works

🤖 Generated with [Claude Code](https://claude.com/claude-code)