### PR TITLE
Manage npmrc via dotfiles symlink

### DIFF
--- a/npm/npmrc
+++ b/npm/npmrc
@@ -1,0 +1,2 @@
+prefix=${HOME}/.npm-global
+min-release-age=7

--- a/npm/setup.sh
+++ b/npm/setup.sh
@@ -1,15 +1,8 @@
 #!/bin/bash
 set -e
 
-# Check if npm prefix is writable by current user
-npm_prefix=$(npm config get prefix)
-if [ ! -w "$npm_prefix" ]; then
-  # Prefix is not writable, reconfigure to user home directory
-  user_npm_dir="$HOME/.npm-global"
-  mkdir -p "$user_npm_dir"
-  npm config set prefix "$user_npm_dir"
-  npm_prefix="$user_npm_dir"
-fi
+mkdir -p "$HOME/.npm-global"
+ln -svf "$DOTFILES_HOME"/npm/npmrc "$HOME"/.npmrc
 
 missing_packages=$(comm -13 <(npm list -g --depth=0 --json 2>/dev/null | jq -r '.dependencies | keys | .[]' 2>/dev/null | sort) <(sort "$DOTFILES_HOME/npm/packages"))
 if [ -n "$missing_packages" ]; then


### PR DESCRIPTION
## Summary
- Track npmrc in dotfiles repo with symlink instead of using `npm config set`
- Set `min-release-age=7` for 7-day package cooldown (supply chain attack mitigation)
- Use `${HOME}` variable for portable prefix path

## Test plan
- [x] Ran `npm/setup.sh` and verified symlink created
- [x] Verified `npm config list` shows correct prefix and `before` date (7 days ago)
- [x] Verified cooldown recomputes dynamically on each npm invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)