### PR TITLE
Add nvim code review keymaps with delta side-by-side diffs

### DIFF
--- a/vim/init.lua
+++ b/vim/init.lua
@@ -86,6 +86,7 @@ local function touch_file()
   vim.fn.system('touch ' .. file)
 end
 vim.keymap.set('n', '<leader>tf', touch_file, {desc = 'Touch a file'})
+vim.keymap.set('n', '<leader>tc', '<cmd>tabclose<cr>', {desc = 'Close tab'})
 
 -- reload my vim config from any buffer
 vim.keymap.set('n', '<f4>', ":source $MYVIMRC<cr>", {desc = 'Reload vim config'})
@@ -136,6 +137,16 @@ end
 
 -- Autocommand to trim whitespace before saving
 vim.cmd([[autocmd BufWritePre * lua _G.trim_whitespace()]])
+
+-- Silently handle files that change on disk: reload if unmodified, keep our
+-- edits if modified. Suppresses the W12 prompt entirely.
+vim.o.autoread = true
+vim.api.nvim_create_autocmd('FileChangedShell', {
+  pattern = '*',
+  callback = function()
+    vim.v.fcs_choice = vim.bo.modified and '' or 'reload'
+  end,
+})
 
 -- highlight all search matches
 vim.o.hlsearch = true
@@ -212,3 +223,8 @@ vim.keymap.set("n", "<leader>cb", "<cmd>ClaudeCodeAdd %<cr>", { desc = "Add curr
 vim.keymap.set("v", "<leader>cs", "<cmd>ClaudeCodeSend<cr>", { desc = "Send to Claude" })
 vim.keymap.set("n", "<leader>ca", "<cmd>ClaudeCodeDiffAccept<cr>", { desc = "Accept diff" })
 vim.keymap.set("n", "<leader>cd", "<cmd>ClaudeCodeDiffDeny<cr>", { desc = "Deny diff" })
+
+-- Code review keymaps (implementation in vim/lua/review.lua)
+local review = require('review')
+vim.keymap.set('n', '<leader>rr', review.vs_head, {desc = 'Review working tree vs HEAD'})
+vim.keymap.set('n', '<leader>rR', review.vs_merge_base, {desc = 'Review vs merge-base with main'})

--- a/vim/lua/review.lua
+++ b/vim/lua/review.lua
@@ -66,6 +66,58 @@ local function find_win_by_term(tab, want_terminal)
   return nil
 end
 
+-- Parse the "new file" line number from a delta side-by-side output line.
+-- Delta's ANSI-stripped format is: │ old_num │ old_content │ new_num │ new_content
+-- The new line number lives in field 4 (after splitting on │).
+local function parse_new_line_num(line)
+  if not line or line == '' then return nil end
+  local parts = vim.split(line, '│', {plain = true})
+  if #parts < 4 then return nil end
+  local num = parts[4]:match('%d+')
+  return num and tonumber(num) or nil
+end
+
+-- Called from <CR> in a review terminal buffer. Walks up from the cursor line
+-- looking for a parseable new-file line number, then jumps the file pane in
+-- the same tab to that line.
+local function jump_to_file_line()
+  local term_buf = vim.api.nvim_get_current_buf()
+  if vim.bo[term_buf].buftype ~= 'terminal' then return end
+  local row = vim.api.nvim_win_get_cursor(0)[1]
+
+  local line_num
+  for r = row, 1, -1 do
+    local line = vim.api.nvim_buf_get_lines(term_buf, r - 1, r, false)[1]
+    local n = parse_new_line_num(line)
+    if n then line_num = n; break end
+  end
+  if not line_num then
+    vim.notify('No diff line number at cursor', vim.log.levels.INFO)
+    return
+  end
+
+  local tab = vim.api.nvim_get_current_tabpage()
+  local file_win = find_win_by_term(tab, false)
+  if not file_win then
+    vim.notify('No file pane in this tab', vim.log.levels.INFO)
+    return
+  end
+  vim.api.nvim_set_current_win(file_win)
+  local file_buf = vim.api.nvim_win_get_buf(file_win)
+  local max_line = vim.api.nvim_buf_line_count(file_buf)
+  vim.api.nvim_win_set_cursor(file_win, {math.min(line_num, max_line), 0})
+  vim.cmd('normal! zz')
+end
+
+-- Run a diff command in a new terminal buffer and wire up review keymaps.
+-- Must be called in the window that should host the terminal.
+local function open_diff_terminal(cmd)
+  vim.cmd('terminal ' .. cmd)
+  vim.bo.buflisted = false
+  vim.keymap.set('t', '<Esc>', [[<C-\><C-n>]], {buffer = true, desc = 'Exit terminal mode'})
+  vim.keymap.set('n', '<CR>', jump_to_file_line, {buffer = true, desc = 'Jump to diff line in file'})
+end
+
 -- Replace (or create) the terminal window's buffer with a fresh diff run.
 local function render_diff_into_tab(tab, root, base_ref, rel, is_untracked)
   vim.api.nvim_set_current_tabpage(tab)
@@ -74,13 +126,11 @@ local function render_diff_into_tab(tab, root, base_ref, rel, is_untracked)
   if term_win then
     vim.api.nvim_set_current_win(term_win)
     local old_buf = vim.api.nvim_win_get_buf(term_win)
-    vim.cmd('terminal ' .. cmd)
-    vim.bo.buflisted = false
+    open_diff_terminal(cmd)
     pcall(vim.api.nvim_buf_delete, old_buf, {force = true})
   else
     vim.cmd('topleft split')
-    vim.cmd('terminal ' .. cmd)
-    vim.bo.buflisted = false
+    open_diff_terminal(cmd)
   end
   -- Leave focus on the diff (terminal) pane.
   local focus_term = find_win_by_term(tab, true)
@@ -161,8 +211,7 @@ local function review_against(base_ref)
         vim.cmd('edit ' .. vim.fn.fnameescape(abs))
         vim.cmd('topleft split')
       end
-      vim.cmd('terminal ' .. build_diff_cmd(root, base_ref, rel, untracked_set[rel] or false))
-      vim.bo.buflisted = false
+      open_diff_terminal(build_diff_cmd(root, base_ref, rel, untracked_set[rel] or false))
     end
   end
 

--- a/vim/lua/review.lua
+++ b/vim/lua/review.lua
@@ -1,0 +1,299 @@
+-- Code review: one tab per changed file, file on top, delta diff below.
+-- Re-running refreshes existing review tabs in place, closes tabs for files no
+-- longer changed, and opens new tabs for newly-changed files. Terminal-width
+-- aware: side-by-side when there's room, unified when narrow.
+
+local M = {}
+
+local WIDE_THRESHOLD = 180
+
+local function is_wide()
+  return vim.o.columns >= WIDE_THRESHOLD
+end
+
+-- Mode (wide vs narrow) at which review tabs were last rendered, so VimResized
+-- knows whether a refresh is needed.
+local last_wide = nil
+
+local function delta_cmd()
+  if is_wide() then
+    return 'delta --side-by-side --paging=never'
+  end
+  return 'delta --paging=never'
+end
+
+local function build_diff_cmd(root, base_ref, rel, is_untracked)
+  if is_untracked then
+    return string.format(
+      'git -C %s diff --no-index -- /dev/null %s | %s',
+      vim.fn.shellescape(root),
+      vim.fn.shellescape(rel),
+      delta_cmd()
+    )
+  end
+  return string.format(
+    'git -C %s diff %s -- %s | %s',
+    vim.fn.shellescape(root),
+    vim.fn.shellescape(base_ref),
+    vim.fn.shellescape(rel),
+    delta_cmd()
+  )
+end
+
+local function git_root()
+  local root = vim.fn.systemlist('git rev-parse --show-toplevel')[1]
+  if vim.v.shell_error ~= 0 or not root or root == '' then
+    return nil
+  end
+  return root
+end
+
+local function fetch_untracked(root)
+  local set = {}
+  local list = vim.fn.systemlist({'git', '-C', root, 'ls-files', '--others', '--exclude-standard'})
+  for _, f in ipairs(list) do set[f] = true end
+  return set
+end
+
+-- Find a window in a tab by whether its buffer is a terminal.
+local function find_win_by_term(tab, want_terminal)
+  for _, win in ipairs(vim.api.nvim_tabpage_list_wins(tab)) do
+    local is_term = vim.bo[vim.api.nvim_win_get_buf(win)].buftype == 'terminal'
+    if is_term == want_terminal then
+      return win
+    end
+  end
+  return nil
+end
+
+-- Replace (or create) the terminal window's buffer with a fresh diff run.
+local function render_diff_into_tab(tab, root, base_ref, rel, is_untracked)
+  vim.api.nvim_set_current_tabpage(tab)
+  local cmd = build_diff_cmd(root, base_ref, rel, is_untracked)
+  local term_win = find_win_by_term(tab, true)
+  if term_win then
+    vim.api.nvim_set_current_win(term_win)
+    local old_buf = vim.api.nvim_win_get_buf(term_win)
+    vim.cmd('terminal ' .. cmd)
+    vim.bo.buflisted = false
+    pcall(vim.api.nvim_buf_delete, old_buf, {force = true})
+  else
+    vim.cmd('topleft split')
+    vim.cmd('terminal ' .. cmd)
+    vim.bo.buflisted = false
+  end
+  -- Leave focus on the diff (terminal) pane.
+  local focus_term = find_win_by_term(tab, true)
+  if focus_term then
+    vim.api.nvim_set_current_win(focus_term)
+  end
+end
+
+-- Re-render every existing review tab's diff at the current terminal width.
+-- Doesn't add or remove tabs. Returns true if any tab was touched.
+local function refresh_all_review_tabs()
+  local root = git_root()
+  if not root then return false end
+  local untracked_set = fetch_untracked(root)
+  local prev_tab = vim.api.nvim_get_current_tabpage()
+  local touched = false
+  for _, tab in ipairs(vim.api.nvim_list_tabpages()) do
+    local ok_f, rel = pcall(vim.api.nvim_tabpage_get_var, tab, 'review_file')
+    local ok_b, base_ref = pcall(vim.api.nvim_tabpage_get_var, tab, 'review_base')
+    if ok_f and rel and ok_b and base_ref then
+      render_diff_into_tab(tab, root, base_ref, rel, untracked_set[rel] or false)
+      touched = true
+    end
+  end
+  pcall(vim.api.nvim_set_current_tabpage, prev_tab)
+  if touched then
+    last_wide = is_wide()
+  end
+  return touched
+end
+
+local function review_against(base_ref)
+  local root = git_root()
+  if not root then
+    vim.notify('Not in a git repo', vim.log.levels.ERROR)
+    return
+  end
+  local files = vim.fn.systemlist({'git', '-C', root, 'diff', '--name-only', base_ref})
+  if vim.v.shell_error ~= 0 then
+    vim.notify('git diff failed for base ' .. base_ref, vim.log.levels.ERROR)
+    return
+  end
+  local untracked_set = fetch_untracked(root)
+  for f in pairs(untracked_set) do table.insert(files, f) end
+
+  local new_set = {}
+  for _, rel in ipairs(files) do new_set[rel] = true end
+
+  -- Walk existing review tabs: refresh ones still changed, close stale ones.
+  local existing = {}
+  for _, tab in ipairs(vim.api.nvim_list_tabpages()) do
+    local ok, rel = pcall(vim.api.nvim_tabpage_get_var, tab, 'review_file')
+    if ok and rel then
+      if new_set[rel] then
+        existing[rel] = true
+        render_diff_into_tab(tab, root, base_ref, rel, untracked_set[rel] or false)
+        vim.t.review_base = base_ref
+      else
+        vim.api.nvim_set_current_tabpage(tab)
+        vim.cmd('tabclose')
+      end
+    end
+  end
+
+  if #files == 0 then
+    vim.notify('No changed files vs ' .. base_ref)
+    return
+  end
+
+  for _, rel in ipairs(files) do
+    if not existing[rel] then
+      local abs = root .. '/' .. rel
+      vim.cmd('tabnew')
+      vim.t.review_file = rel
+      vim.t.review_base = base_ref
+      local has_file = vim.fn.filereadable(abs) == 1
+      if has_file then
+        vim.cmd('edit ' .. vim.fn.fnameescape(abs))
+        vim.cmd('topleft split')
+      end
+      vim.cmd('terminal ' .. build_diff_cmd(root, base_ref, rel, untracked_set[rel] or false))
+      vim.bo.buflisted = false
+    end
+  end
+
+  last_wide = is_wide()
+
+  -- Jump to the first review tab (skip any pre-existing non-review tabs).
+  for _, tab in ipairs(vim.api.nvim_list_tabpages()) do
+    local ok, rel = pcall(vim.api.nvim_tabpage_get_var, tab, 'review_file')
+    if ok and rel then
+      vim.api.nvim_set_current_tabpage(tab)
+      break
+    end
+  end
+end
+
+local function merge_base()
+  for _, b in ipairs({'main', 'master'}) do
+    local mb = vim.fn.systemlist({'git', 'merge-base', 'HEAD', b})[1]
+    if vim.v.shell_error == 0 and mb and mb ~= '' then
+      return mb
+    end
+  end
+  return nil
+end
+
+-- Tabline: label review tabs with the shortest trailing path suffix that
+-- uniquely identifies the file among all currently-open tabs. Non-review tabs
+-- use the same logic based on their buffer name.
+local function split_path(path)
+  local parts = {}
+  for p in path:gmatch('[^/]+') do table.insert(parts, p) end
+  if #parts == 0 then parts = {path} end
+  return parts
+end
+
+local function suffix_of(parts, n)
+  local take = math.min(n, #parts)
+  return table.concat(parts, '/', #parts - take + 1, #parts)
+end
+
+-- For each path, pick the shortest n such that suffix_of(parts[i], n) doesn't
+-- collide with any other tab's suffix at that same level.
+local function unique_suffixes(paths)
+  local parts, depths = {}, {}
+  for i, p in ipairs(paths) do
+    parts[i] = split_path(p)
+    depths[i] = 1
+  end
+  while true do
+    local groups = {}
+    for i = 1, #paths do
+      local lbl = suffix_of(parts[i], depths[i])
+      groups[lbl] = groups[lbl] or {}
+      table.insert(groups[lbl], i)
+    end
+    local extended = false
+    for _, members in pairs(groups) do
+      if #members > 1 then
+        for _, idx in ipairs(members) do
+          if depths[idx] < #parts[idx] then
+            depths[idx] = depths[idx] + 1
+            extended = true
+          end
+        end
+      end
+    end
+    if not extended then break end
+  end
+  local labels = {}
+  for i = 1, #paths do
+    labels[i] = suffix_of(parts[i], depths[i])
+  end
+  return labels
+end
+
+function M.tabline()
+  local tabs = vim.api.nvim_list_tabpages()
+
+  local paths = {}
+  for i, tab in ipairs(tabs) do
+    local ok, rel = pcall(vim.api.nvim_tabpage_get_var, tab, 'review_file')
+    if ok and rel and rel ~= '' then
+      paths[i] = rel
+    else
+      local win = vim.api.nvim_tabpage_get_win(tab)
+      local name = vim.api.nvim_buf_get_name(vim.api.nvim_win_get_buf(win))
+      paths[i] = name == '' and '[No Name]' or name
+    end
+  end
+
+  local labels = unique_suffixes(paths)
+
+  local out = {}
+  local cur = vim.api.nvim_get_current_tabpage()
+  for i, tab in ipairs(tabs) do
+    local hl = (tab == cur) and '%#TabLineSel#' or '%#TabLine#'
+    table.insert(out, hl)
+    table.insert(out, '%' .. i .. 'T')
+    table.insert(out, ' ' .. labels[i] .. ' ')
+  end
+  table.insert(out, '%#TabLineFill#%T')
+  return table.concat(out)
+end
+
+_G.__review_tabline = M.tabline
+vim.o.tabline = '%!v:lua.__review_tabline()'
+
+function M.vs_head()
+  review_against('HEAD')
+end
+
+function M.vs_merge_base()
+  local mb = merge_base()
+  if not mb then
+    vim.notify('No main/master branch found', vim.log.levels.ERROR)
+    return
+  end
+  review_against(mb)
+end
+
+-- On terminal resize, re-render review tabs if we've crossed the wide/narrow
+-- threshold. Uses an augroup so re-loading the module doesn't stack autocmds.
+vim.api.nvim_create_augroup('ReviewResize', {clear = true})
+vim.api.nvim_create_autocmd('VimResized', {
+  group = 'ReviewResize',
+  callback = function()
+    if last_wide == nil then return end
+    if is_wide() ~= last_wide then
+      refresh_all_review_tabs()
+    end
+  end,
+})
+
+return M

--- a/vim/setup.sh
+++ b/vim/setup.sh
@@ -6,6 +6,7 @@ echo "$packer_path"
 # symlink .config/nvim/init.vim
 mkdir -p "$HOME/.config/nvim"
 ln -svf "$DOTFILES_HOME/vim/init.lua" "$HOME/.config/nvim/init.lua"
+ln -svf "$DOTFILES_HOME/vim/lua" "$HOME/.config/nvim/lua"
 
 # symlink .vim
 ln -svf "$DOTFILES_HOME/vim/.vim" "$HOME"


### PR DESCRIPTION
## Summary

- `<leader>rr` / `<leader>rR` open one tab per changed file showing `git diff | delta --side-by-side` in a terminal pane on top and the current file below. `rr` diffs vs `HEAD`; `rR` diffs vs `merge-base` with `main` (fallback `master`).
- Re-running refreshes existing review tabs in place, closes tabs for files no longer changed, and opens new tabs for newly-changed files. Untracked files are included via `git diff --no-index`.
- On `VimResized` across a 180-column threshold the diff panes re-render in unified (<180) or side-by-side (>=180) layout.
- Custom tabline labels each review tab with the shortest trailing path suffix that uniquely identifies the file among open tabs, so `vim/init.lua` and `whisper/init.lua` get two-component labels while a unique `README.md` stays bare.
- `<CR>` on any line in the diff terminal pane jumps the file pane in the same tab to that line (centered). `<Esc>` in terminal-job mode drops into Terminal-Normal mode so you can navigate the diff with `hjkl` first.
- Implementation lives in `vim/lua/review.lua`; `vim/setup.sh` now symlinks `~/.config/nvim/lua` to `vim/lua`.
- Tag-along quality-of-life fixes: `<leader>tc` closes the whole tab (handy for the many-tabs review workflow), and a `FileChangedShell` autocmd silently reloads unmodified buffers / keeps modified ones (suppresses the `W12` prompt).

## Test plan

- [ ] Restart nvim so the new `~/.config/nvim/lua` symlink is picked up
- [ ] Modify a tracked file, press `<leader>rr` → one tab opens with delta side-by-side diff on top, file on bottom; tabline shows the filename
- [ ] Create an untracked file, press `<leader>rr` → new tab appears showing the file as all-added
- [ ] Re-run `<leader>rr` → tabs refresh in place, no duplicates
- [ ] Commit changes on a branch, press `<leader>rR` → diffs against merge-base with main
- [ ] Resize terminal across the 180-column threshold → panes re-render in the new layout
- [ ] In the diff pane press `<Esc>` then `<CR>` on a changed line → file pane jumps to that line
- [ ] Open two files with the same basename in different dirs → tabline shows disambiguated labels
- [ ] `<leader>tc` closes the whole tab
- [ ] Edit a file in nvim while it changes on disk → no `W12` prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)