### PR TITLE
Tweak claude slash commands: add /simplify-agent, simplify /merge

### DIFF
--- a/claude/commands/merge.md
+++ b/claude/commands/merge.md
@@ -4,12 +4,11 @@ Follow these steps:
 
 1. Get the current PR number using `gh pr view --json number -q .number`
 
-2. Check the CI status using `gh pr checks --json state,bucket -q '.[] | select(.required == true) | {state: .state, bucket: .bucket}'`
+2. Wait for CI to finish using `gh pr checks --watch` (this blocks until all checks complete — no manual polling loop needed). Use a generous timeout on the Bash call.
 
-3. Based on the CI status:
-   - **If all required checks are passing (bucket: "pass")**: Proceed to merge immediately
-   - **If any checks are pending (bucket: "pending")**: Poll every 10 seconds with `sleep 10 && gh pr checks` until no longer pending, reporting progress to the user (e.g., "CI still running, checking again in 10 seconds..."). Once no longer pending, check if passed or failed.
-   - **If any checks failed (bucket: "fail")**: Notify the user that CI failed and abort without merging
+3. Based on the final result:
+   - **If all checks passed**: Proceed to merge immediately
+   - **If any check failed**: Notify the user that CI failed and abort without merging
 
 4. If CI passed: Execute `gh pr merge --merge --delete-branch` to merge with a merge commit and delete both local and remote branches
 

--- a/claude/commands/simplify-agent.md
+++ b/claude/commands/simplify-agent.md
@@ -1,0 +1,5 @@
+Invoke the code-simplifier agent to review and refine recently modified code for clarity, consistency, and maintainability while preserving all functionality.
+
+Additional context from the user: $ARGUMENTS
+
+Use the code-simplifier agent. If the user supplied specific files, focus the agent on those. If they supplied other instructions (e.g. "skip the tests", "only the auth module"), pass those along as part of the agent's prompt. If $ARGUMENTS is empty, let the agent default to recently modified code.


### PR DESCRIPTION
## Summary

- **Add \`/simplify-agent\`** — thin wrapper around the code-simplifier agent for a one-shot simplification pass with optional file/scope context (e.g. \`/simplify-agent foo.c\`). Distinct from the built-in \`/simplify\` skill, which runs a multi-axis reuse/quality/efficiency review.
- **Simplify \`/merge\`** — use \`gh pr checks --watch\` to block until CI finishes rather than the manual sleep-based polling loop. Cleaner, and avoids the long-sleep safety guard on the Bash tool.

## Test plan

- [ ] \`/simplify-agent\` tab-completes in a fresh Claude Code session
- [ ] \`/simplify-agent some/file.c please\` passes the context through to the code-simplifier agent
- [ ] \`/merge\` on a PR with pending CI waits for checks and merges when they pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)