### PR TITLE
Silence gh pr checks --watch spam in /merge

### DIFF
--- a/claude/commands/merge.md
+++ b/claude/commands/merge.md
@@ -4,7 +4,7 @@ Follow these steps:
 
 1. Get the current PR number using `gh pr view --json number -q .number`
 
-2. Wait for CI to finish using `gh pr checks --watch` (this blocks until all checks complete — no manual polling loop needed). Use a generous timeout on the Bash call.
+2. Wait for CI to finish using `gh pr checks <number> --watch > /dev/null && gh pr checks <number>` — the first call blocks until checks complete (discarding its noisy per-refresh output), and the second produces one clean final-state block. Use a generous timeout on the Bash call.
 
 3. Based on the final result:
    - **If all checks passed**: Proceed to merge immediately


### PR DESCRIPTION
## Summary

\`gh pr checks --watch\` prints the full check state on every refresh cycle (roughly 30+ lines per merge) — that all goes into Claude's conversation context and adds up across a session. This PR updates \`/merge\` to redirect the streaming output to \`/dev/null\` and run a single \`gh pr checks\` query after it exits for the final state. Same wait semantics, one clean block instead of a polling log.

## Test plan

- [ ] Run \`/merge\` on this PR itself. The merge wait should block correctly while CI runs, produce one block of check state after CI finishes, and proceed to the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)