### PR TITLE
Add river app autostart and waybar pending-reboot indicator

### DIFF
--- a/river/init
+++ b/river/init
@@ -201,3 +201,5 @@ dbus-update-activation-environment --systemd WAYLAND_DISPLAY XDG_CURRENT_DESKTOP
 
 pkill rivertile 2>/dev/null || true
 setsid rivertile -view-padding 5 -outer-padding 5 -main-ratio 0.5 &
+
+"$DOTFILES_HOME/river/start_apps.sh"

--- a/river/start_apps.sh
+++ b/river/start_apps.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Start common apps on their designated tags at login.
+# Rules are added pre-spawn, then removed after a wait long enough for every
+# window to have mapped — so only the startup windows get routed and later
+# launches of the same apps aren't stuck to these tags.
+#
+# Waybar tag icons:
+#   1 🖥️ — foot (primary terminal)
+#   2 🌐 — zen-browser
+#   4 🔐 — keepassxc
+
+riverctl rule-add -app-id foot      tags $((1 << 0))
+riverctl rule-add -app-id zen       tags $((1 << 1))
+riverctl rule-add -app-id org.keepassxc.KeePassXC tags $((1 << 3))
+
+riverctl spawn foot
+riverctl spawn keepassxc
+riverctl spawn zen-browser
+
+# Wait long enough for the slowest window to map before tearing down rules.
+sleep 5
+
+riverctl rule-del -app-id foot      tags
+riverctl rule-del -app-id zen       tags
+riverctl rule-del -app-id org.keepassxc.KeePassXC tags

--- a/waybar/config
+++ b/waybar/config
@@ -15,6 +15,7 @@
 	],
 	"modules-right": [
 		"custom/nag-runner",
+		"custom/kernel-reboot",
 		"custom/controller",
 		"custom/network",
 		"pulseaudio",
@@ -104,6 +105,12 @@
 		"exec": "$HOME/Projects/nag-runner/nag_runner.py --check && echo '' || echo '⚠️'",
 		"tooltip": true,
 		"tooltip-format": "Nags Overdue!"
+	},
+	"custom/kernel-reboot": {
+		"interval": 60,
+		"exec": "[ -d \"/usr/lib/modules/$(uname -r)\" ] && echo '' || echo '🔃'",
+		"tooltip": true,
+		"tooltip-format": "Kernel updated — reboot pending"
 	},
 	"custom/controller": {
 		"interval": 10,


### PR DESCRIPTION
## Summary
- `river/start_apps.sh`: launches foot, zen-browser, and keepassxc on their designated waybar tags at login. Uses temporary `rule-add` / `rule-del` around spawns so tag routing only applies to the startup windows — later launches follow the focused tag as normal.
- `river/init`: invokes `start_apps.sh` after rivertile is registered, so windows tile at spawn (earlier placement left windows floating).
- `waybar/config`: new `custom/kernel-reboot` module shows 🔃 when `/usr/lib/modules/\$(uname -r)` is missing. Pacman removes the running kernel's modules directory on upgrade, which is what causes the "module not found" issues until reboot — this surfaces that state on the bar.

## Test plan
- [x] Reboot: foot lands on tag 1, zen on tag 2, keepass on tag 4, all tiled
- [x] Launching zen/keepass later from the launcher follows focused tag (not sticky)
- [x] Kernel-reboot icon hidden when running kernel matches installed modules
- [x] Kernel-reboot icon shows 🔃 when the running kernel's modules directory is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)