### PR TITLE
Enable tmux extended-keys for modified Enter key support

### DIFF
--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -7,7 +7,8 @@ bind C-Space send-prefix
 # Enable mouse support
 set -g mouse on
 
-# Focus events enabled for terminals that support them
+# Enable extended keys for modified key support in TUI apps
+set -g extended-keys on
 set -g focus-events on
 
 # Set default terminal with true color support
@@ -32,9 +33,6 @@ set -g display-time 4000
 
 # Refresh status line more often
 set -g status-interval 5
-
-# Focus events enabled for terminals that support them
-set -g focus-events on
 
 # Super useful when using "grouped sessions" and multi-monitor setup
 setw -g aggressive-resize on


### PR DESCRIPTION
Add `set -g extended-keys on` to fix modified Enter keys not working inside tmux (Shift+Enter, Alt+Enter). Also removed a duplicate `set -g focus-events on` line.