### PR TITLE
Add agent-skills/ and migrate slash commands to skills

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ test-all: # Run both minimal and core tests
 
 lint: # Run shellcheck on shell files and ruff on Python files
 	@echo "Running shellcheck on shell files.."
-	find . -name "*.sh" -o -path "./river/init" | grep -v ".git" | grep -v "scratch" | grep -v ".venv" | xargs shellcheck
+	find . -name "*.sh" -o -path "./river/init" | grep -v ".git" | grep -v "scratch" | grep -v ".venv" | grep -v ".Trash" | xargs shellcheck
 	@echo "Running ruff on Python files.."
 	cd whisper && uv run ruff check . && cd ..
 	@echo "Checking package files are alphabetically sorted.."

--- a/agent-skills/address-pr-feedback/SKILL.md
+++ b/agent-skills/address-pr-feedback/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: address-pr-feedback
+description: Review automated PR feedback, discuss with the user, fix what they approve, respond to comments, and push
+disable-model-invocation: false
+argument-hint: "[pr-number]"
+---
+
+Address automated review feedback on PR #$ARGUMENTS.
+
+## Steps
+
+1. **Fetch review comments** using `/pr-comments` first, then supplement with both GitHub API endpoints to ensure full coverage:
+   - `gh api repos/{owner}/{repo}/pulls/{pr}/comments` — inline review comments on specific lines
+   - `gh api repos/{owner}/{repo}/issues/{pr}/comments` — general conversation comments (where automated review bots like the CI code review post)
+
+   Combine results from all sources, deduplicating and ignoring bot comments that aren't code review feedback (e.g., Vercel deployment status, coverage reports).
+
+2. **Summarize each suggestion** with your assessment of whether it's worth fixing. Present as a numbered table with columns: suggestion, your take (fix/skip + rationale). Be opinionated.
+
+3. **Discuss with the user.** Wait for them to tell you which suggestions to act on and which to skip. They may have additional context or disagree with your assessment.
+
+4. **Implement the agreed fixes.** Make the code changes, run type-check and tests to verify.
+
+5. **Respond to the review comments** on the PR via `gh api repos/{owner}/{repo}/issues/{pr}/comments`. Mention that you're Claude speaking on @thavelick's behalf. Address each numbered suggestion: what was done and why, or why it was skipped.
+
+6. **Commit and push** the changes.

--- a/agent-skills/competitive-seo-analysis/SKILL.md
+++ b/agent-skills/competitive-seo-analysis/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: Competitive SEO Analysis
+description: Conduct systematic SEO competitive analysis for landing pages by auditing current content, identifying target keywords, analyzing competitor strategies, and generating data-driven recommendations. Use when you need to improve search rankings, find content gaps, or develop SEO strategy based on competitor insights.
+allowed-tools: Bash, Grep, Read, Glob, Write
+---
+
+# Competitive SEO Analysis
+
+## Purpose
+This skill guides a systematic competitive analysis process to improve SEO performance by analyzing competitor content, identifying gaps, and creating actionable recommendations.
+
+## When to Use This Skill
+- Analyzing existing landing pages or form pages for SEO improvement
+- Planning and researching new pages before creation
+- Comparing your content against competitor strategies
+- Identifying content gaps and missing information
+- Planning SEO enhancements with data-driven insights
+- Creating comprehensive competitive analysis reports
+
+## Analysis Process
+
+### Phase 1: Current Page Audit or New Page Planning
+**For existing pages:**
+1. **Review existing page structure** - Examine the current page's content, headings, meta tags, schema markup
+2. **Extract target keywords** - Identify primary keywords, secondary variations, and long-tail opportunities from:
+   - Meta keywords field
+   - H1 and H2 headings
+   - Current page content focus
+3. **Document current state** - Note what's already optimized and what gaps exist
+
+**For new pages:**
+1. **Define target keywords** - Identify the primary topic and keyword phrases the page should rank for
+2. **Document intended purpose** - Clarify the page's role and user intent (how-to, reference, comparison, etc.)
+3. **Note any existing content** - If repurposing or building on existing materials, document what resources are available
+
+### Phase 2: Competitive Research
+1. **Run targeted searches** - Use `searxng_search.py` which is in your PATH. Run the
+   script by name only (no path prefix). Exclude Reddit and YouTube results, and use
+   Google-only results with `!startpage` flag:
+   ```bash
+   searxng_search.py --full-count 3 -n 3 "[KEYWORD] -site:reddit.com
+   -site:youtube.com !startpage"
+   ```
+   Run 3 separate searches:
+   - 1 primary keyword search
+   - 1 secondary keyword search
+   - 1 long-tail keyword search
+
+   **Important**: If `searxng_search.py` doesn't work or produces errors, abort
+   immediately and ask for help. Do NOT fall back to WebFetch or other tools.
+
+   If you receive authorization failures (403 Forbidden) from a site, exclude that
+   domain and rerun the search to get results from alternative competitors:
+   ```bash
+   searxng_search.py --full-count 3 -n 3 "[KEYWORD] -site:blocked-domain.com
+   -site:reddit.com -site:youtube.com !startpage"
+   ```
+
+2. **Analyze top 3 competitors** - Focus analysis on the top 3 unique competitor
+   sites (excluding blocked/unauthorized sites). For each competitor, focus on:
+   - Non-government competitors (form generation sites, tax software, document
+     services)
+   - Page titles and meta descriptions
+   - Content structure and organization
+   - Content sections and schema markup
+   - Value propositions and unique features
+
+### Phase 3: Content Gap Analysis
+Compare your content against competitors and identify:
+- Missing deadline information
+- Limited form comparison content
+- Lack of error prevention guidance
+- Insufficient user journey support
+- Technical complexity barriers
+- Missing process guidance
+- Incomplete content coverage
+
+### Phase 4: Generate Recommendations
+Create actionable suggestions for:
+- Content enhancements addressing identified gaps
+- SEO technical improvements (meta descriptions, schema, structure)
+
+### Phase 5: Quality Assurance
+
+**Originality and Plagiarism Avoidance:**
+- Use different perspectives and approaches than competitors
+- Focus on solutions rather than just problems
+- Create unique content flow and organization
+- Include company-specific insights and features
+- Add practical steps and processes unique to your offering
+- Use conversational, helpful tone that reflects your brand voice
+
+**Content Validation:**
+- Verify accuracy of technical information
+- Ensure recommendations align with user intent
+- Validate SEO optimization elements
+- Confirm originality and uniqueness of suggested content
+
+**Documentation:**
+- For existing pages: Create analysis document with findings and recommendations
+- For new pages: Create a comprehensive outline/specification including target
+  keywords, content sections, unique value propositions, and SEO elements
+- Document expected SEO impact and success metrics
+- Save output to `/tmp/competitive-analysis-[topic].md` with the structured
+  template below
+- **Line wrapping**: After writing the document, fold output to 98 characters
+  maximum, breaking only at word boundaries:
+  ```bash
+  fold -w 98 -s /tmp/competitive-analysis-[topic].md > /tmp/temp.md && \
+  mv /tmp/temp.md /tmp/competitive-analysis-[topic].md
+  ```
+
+## Key Principles
+
+**Data-driven**: Base all recommendations on actual competitor analysis, not assumptions.
+
+**Actionable**: Provide specific, implementable recommendations with clear expected outcomes.
+
+**Original**: Create unique content approaches that differentiate from competitors rather than copying.
+
+**Comprehensive**: Cover all content aspects—structure, keywords, FAQs, schema, and user experience.
+
+## Output Format
+
+Create a detailed analysis document including:
+- Audit findings from current page
+- Target keywords identified
+- Competitor summary (top 3 competitors analyzed)
+- Content gaps discovered
+- SEO technical opportunities
+- Specific implementation recommendations
+
+## Examples
+
+**Example 1: Improve Existing Page**
+- Input: Audit W2 form landing page with outdated startup tax content
+- Process: Run 3 searches (primary: "w2 form", secondary: "w2 tax form", long-tail:
+  "how to file w2 as freelancer") and analyze top 3 competitors
+- Output: Recommendations to remove irrelevant content, integrate builder help
+  content, add deadline info, improve content coverage
+
+**Example 2: Plan New Product Landing Page**
+- Input: Plan new product page targeting "tax software for freelancers"
+- Process: Run 3 targeted searches (primary: "tax software for freelancers",
+  secondary: "freelancer tax tools", long-tail: "best tax software for self-employed
+  contractors") to find competitor pages
+- Output: Page outline including target keywords, recommended content sections,
+  unique value propositions, schema markup opportunities, and competitive advantages
+  to emphasize
+
+**Example 3: Competitive Comparison**
+- Input: Analyze product page against top competitors
+- Process: Run 3 searches to identify gaps in feature descriptions, comparison
+  content, use cases from top 3 competitors
+- Output: Content recommendations to outrank competitors and capture long-tail
+  keywords
+
+## Output Template
+
+Save analysis results to `/tmp/competitive-analysis-[topic].md` with this structure:
+
+```markdown
+# Competitive SEO Analysis: [Topic/Page Name]
+
+## Summary
+[Brief overview of the analysis scope and key findings]
+
+## Target Keywords
+- Primary: [primary keyword phrases]
+- Secondary: [secondary keyword variations]
+- Long-tail: [long-tail opportunities]
+
+## Competitors Analyzed
+1. [Competitor 1 URL]
+2. [Competitor 2 URL]
+3. [Competitor 3 URL]
+
+## Competitor Analysis
+
+### Competitor 1: [Name]
+- **URL**: [url]
+- **Page Title**: [title strategy]
+- **Meta Description**: [description approach]
+- **Key Content Sections**: [main sections identified]
+- **Schema Markup**: [structured data implementation]
+- **Content Approach**: [how they structure and present information]
+
+### Competitor 2: [Name]
+[Same structure]
+
+### Competitor 3: [Name]
+[Same structure]
+
+## Content Gaps Identified
+- [Gap 1: specific missing content]
+- [Gap 2: missing information]
+- [Gap 3: weak coverage area]
+- [Gap 4: opportunity]
+
+## Recommendations
+
+### Content Enhancements
+- [Specific recommendation 1]
+- [Specific recommendation 2]
+- [Specific recommendation 3]
+
+### SEO Technical Improvements
+- Meta title optimization: [specific suggestion]
+- Meta description: [specific suggestion]
+- Schema markup: [specific implementation]
+- Internal linking: [strategy]
+
+## Implementation Notes
+[Any specific context, constraints, or additional guidance for implementation]
+```
+
+## Tools Used
+- `searxng_search.py`: Primary tool for competitive research and finding top-ranking
+  pages. This script is in your PATH and should be run by name only (no path prefix).
+  If the tool doesn't work or produces errors, abort immediately and ask for help.
+  Do NOT fall back to WebFetch or other tools.
+  - `--full-count 3`: Get full content and metadata for results
+  - `-n 3`: Number of search results to return
+  - `-site:domain.com`: Exclude specific domains from results
+  - `!startpage`: Return Google-only results
+- Grep: Search existing codebase for related content
+- Read: Examine current page structure
+- Glob: Find related files and documentation
+- Bash: Run search commands, manage analysis, and fold output to 98 characters
+  with word boundary breaking using `fold -w 98 -s`

--- a/agent-skills/cut-branch/SKILL.md
+++ b/agent-skills/cut-branch/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: cut-branch
+description: Create a new git branch for working on a feature or fix
+argument-hint: "[issue-number or description]"
+---
+
+Create a new git branch following the naming convention: `description_of_issue_<github-issue-number>`
+
+## Process
+
+1. **Determine the issue number**:
+   - If `$ARGUMENTS` contains a number, use that as the issue number
+   - If `$ARGUMENTS` is empty or doesn't contain an issue number, ask the user for it
+   - The user may say there is no ticket - that's okay, proceed without one
+
+2. **Check for existing branch** (if there is an issue number):
+   - Run: `git pull && git branch -a | grep _<number>$`
+   - If a branch already exists for this issue, ask the user if they want to check it out instead (skip remaining steps)
+
+3. **Fetch issue details** (if there is an issue number):
+   1. Check if the project has a `.issues` directory by running: `[ -d .issues ] && echo ".issues directory found" || echo ".issues directory not found"`
+   2. If the `.issues` directory exists: use `gh-issue-sync pull && gh-issue-sync view <number>` to get the issue title
+   3. If the `.issues` directory does NOT exist: use `gh issue view <number>` to get the issue title
+
+4. **Generate branch name**:
+   - Use your judgment to create a short, descriptive branch name based on the issue title
+   - Use underscores between words, keep it lowercase
+   - If there's an issue number, append `_<number>` at the end
+
+5. **Create and checkout the branch**:
+   ```bash
+   git checkout -b <branch-name>
+   ```
+
+6. **Confirm to the user** what branch was created and from what base branch.
+
+## Examples
+
+- Issue #42 titled "Fix login button alignment" → `fix_login_button_42`
+- Issue #100 titled "Add OAuth2 support for third-party apps" → `oauth2_support_100`
+- No ticket, user describes "refactor database queries" → `refactor_db_queries`

--- a/agent-skills/dev-workflow/SKILL.md
+++ b/agent-skills/dev-workflow/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: dev-workflow
+description: Start working on a ticket, dev workflow, work on an issue, pick up a ticket
+disable-model-invocation: false
+argument-hint: "[issue-number-or-description]"
+---
+
+Run the full developer workflow end-to-end: pick a ticket, branch, plan, implement, commit, simplify, PR, wait for CI, and address feedback. Execute each step sequentially, waiting for completion before moving to the next.
+
+## Steps
+
+1. **Ticket selection**:
+   - If `$ARGUMENTS` is provided, treat it as an issue number or description.
+   - Otherwise, run `gh issue list --assignee @me --limit 10` to show issues assigned to the user.
+   - If no issues are found assigned to the user, fall back to `gh issue list --limit 10`.
+   - Present the list and ask the user to pick one.
+
+2. **Ticket creation** (if no existing ticket matches):
+   - Draft the ticket body and write it to a temporary file (e.g., `/tmp/issue-draft.md`).
+   - Propose all attributes, including project fields, and ask the user to review the body file and confirm the attributes before running any creation command.
+   - Only after explicit approval, run `gh issue create` with the approved values.
+
+3. **Branch creation**: Invoke the `cut-branch` skill with the issue number.
+
+4. **Planning**: Invoke `EnterPlanMode` (the built-in `/plan` command). Present a plan for implementing the ticket. Wait for the user to approve the plan before continuing.
+
+5. **Implementation**: Execute the approved plan. Build the feature or fix step-by-step.
+
+6. **Visual/functional verification** (conditional): If the implementation touched UI components, styles, layouts, or templates, spawn a Playwright subagent to verify the feature works as intended. The agent should use its best judgment on verification method (screenshots, checking DOM elements, verifying text content, testing interactions, etc.). If verification passes, proceed without waiting for approval. If it fails, fix the issue before continuing.
+
+7. **Initial commit**: Invoke the `commit-commands:commit` skill.
+
+8. **Simplify**: Invoke the `simplify-agent` skill on the changed code. This step is for pre-PR cleanup — refactoring to cleaner code, removing duplication, improving reuse. It is NOT for addressing PR review feedback (that's step 11). The `simplify-agent` skill launches code-simplifier agents that review for reuse, quality, and efficiency issues, then fix what they find.
+
+9. **Push & PR**: Invoke the `commit-commands:commit-push-pr` skill.
+
+10. **Wait for CI**: Spawn a background agent that watches `gh pr checks` until all checks complete, then reports pass/fail. Continue to the next step only after the background agent completes.
+
+11. **Address feedback**: Invoke the `address-pr-feedback` skill with the PR number. This handles automated review bot feedback and human reviewer comments — different from the simplify step which is a pre-PR self-review.
+
+12. **Final review**: Ask the user if they have further feedback on the PR. If so, address it. If not, the workflow is complete.

--- a/agent-skills/grill-me/ATTRIBUTION.md
+++ b/agent-skills/grill-me/ATTRIBUTION.md
@@ -1,0 +1,2 @@
+Original author: Matt Pocock
+Source: https://github.com/mattpocock/skills (skills/productivity/grill-me)

--- a/agent-skills/grill-me/SKILL.md
+++ b/agent-skills/grill-me/SKILL.md
@@ -1,0 +1,10 @@
+---
+name: grill-me
+description: Interview the user relentlessly about a plan or design until reaching shared understanding, resolving each branch of the decision tree. Use when user wants to stress-test a plan, get grilled on their design, or mentions "grill me".
+---
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.

--- a/agent-skills/merge/SKILL.md
+++ b/agent-skills/merge/SKILL.md
@@ -1,6 +1,11 @@
-Merge the current PR with branch deletion, but only after CI passes.
+---
+name: merge
+description: Merge the current PR with branch deletion, but only after CI passes. Use when the user clearly means "merge the open PR" (e.g. plain "merge", "merge it", "ship it"). Do NOT use for git branch merges ("merge main into X") or code merges.
+---
 
-Follow these steps:
+First, confirm intent. Only proceed with this skill if it's obvious the user means "merge the current open PR." If they mean a git branch merge (e.g. "merge main into our branch") or a code merge (combining functions, files, etc.), stop and handle what they actually asked for instead.
+
+If a PR merge is intended, follow these steps:
 
 1. Get the current PR number using `gh pr view --json number -q .number`
 

--- a/agent-skills/setup.sh
+++ b/agent-skills/setup.sh
@@ -1,4 +1,18 @@
 #!/bin/sh
+TARGET="$HOME/.claude/skills"
+SOURCE="$DOTFILES_HOME/agent-skills"
+
 mkdir -p "$HOME/.claude"
-rm -rf "$HOME/.claude/skills"
-ln -svf "$DOTFILES_HOME/agent-skills" "$HOME/.claude/skills"
+
+if [ -L "$TARGET" ] && [ "$(readlink "$TARGET")" = "$SOURCE" ]; then
+  echo "$TARGET already linked to $SOURCE"
+  exit 0
+fi
+
+if [ -e "$TARGET" ] || [ -L "$TARGET" ]; then
+  printf '\033[1;31m⚠️  WARNING: %s already exists and is not the expected symlink.\033[0m\n' "$TARGET" >&2
+  printf '\033[1;31m⚠️  Refusing to overwrite. Move or remove it manually, then re-run.\033[0m\n' >&2
+  exit 1
+fi
+
+ln -svf "$SOURCE" "$TARGET"

--- a/agent-skills/setup.sh
+++ b/agent-skills/setup.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+mkdir -p "$HOME/.claude"
+rm -rf "$HOME/.claude/skills"
+ln -svf "$DOTFILES_HOME/agent-skills" "$HOME/.claude/skills"

--- a/agent-skills/simplify-agent/SKILL.md
+++ b/agent-skills/simplify-agent/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: simplify-agent
+description: Review changed code for reuse, quality, and efficiency using the code-simplifier agent
+---
+
+Launch the code-simplifier agent to review recently changed code for reuse, quality, and efficiency, then fix any issues found.
+
+Use the Agent tool with `subagent_type: "code-simplifier:code-simplifier"` and pass along any arguments the user provided as additional context.

--- a/claude/commands/simplify-agent.md
+++ b/claude/commands/simplify-agent.md
@@ -1,5 +1,0 @@
-Invoke the code-simplifier agent to review and refine recently modified code for clarity, consistency, and maintainability while preserving all functionality.
-
-Additional context from the user: $ARGUMENTS
-
-Use the code-simplifier agent. If the user supplied specific files, focus the agent on those. If they supplied other instructions (e.g. "skip the tests", "only the auth module"), pass those along as part of the agent's prompt. If $ARGUMENTS is empty, let the agent default to recently modified code.

--- a/whisper/uv.lock
+++ b/whisper/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 
+[options]
+exclude-newer = "2026-05-03T19:53:43.304291Z"
+exclude-newer-span = "P1W"
+
 [[package]]
 name = "av"
 version = "15.1.0"


### PR DESCRIPTION
## Summary
- Move `~/.claude/skills/` into the repo at `agent-skills/` so user skills sync across machines. Folder name is generic since the skill format is portable to other agent runtimes (Codex, etc.).
- Migrate `claude/commands/merge.md` and `claude/commands/simplify-agent.md` to skills — auto-discoverable, `/`-invocable, and more portable. The new `merge` skill includes intent disambiguation so it doesn't fire on phrases like "merge main into X".
- Add `agent-skills/setup.sh` to symlink `~/.claude/skills -> agent-skills/`. Run manually, matching `claude/setup.sh`.
- Include attribution for the grill-me skill (originally from mattpocock/skills) in `agent-skills/grill-me/ATTRIBUTION.md`.
- Exclude `.Trash` from shellcheck in the `Makefile` lint target.
- Includes an unrelated `whisper/uv.lock` change: a global uv `exclude-newer` setting got stamped into the lockfile when `make lint` ran `uv run ruff`. Committed alongside so the working tree is clean.

## Test plan
- [x] `make lint` passes
- [x] `agent-skills/setup.sh` produces a symlink at `~/.claude/skills`
- [x] In a fresh Claude Code session, `/grill-me`, `/merge`, `/simplify-agent` are listed as available skills
- [ ] Plain "merge" auto-triggers the merge skill; "merge main into X" does NOT

🤖 Generated with [Claude Code](https://claude.com/claude-code)