### PR TITLE
Add screenshot agent-skill (and pin Claude theme)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,8 @@ lint: # Run shellcheck on shell files and ruff on Python files
 	./tools/check-package-sort.sh
 	@echo "Checking Claude theme is pinned.."
 	./tools/check-claude-theme.sh
+	@echo "Checking Claude settings are formatted.."
+	./tools/check-claude-settings-format.sh
 
 format: # Format Python files with black and JSON files with jq
 	@echo "Formatting Python files with black.."

--- a/Makefile
+++ b/Makefile
@@ -76,9 +76,15 @@ lint: # Run shellcheck on shell files and ruff on Python files
 	@echo "Checking Claude theme is pinned.."
 	./tools/check-claude-theme.sh
 
-format: # Format Python files with black
+format: # Format Python files with black and JSON files with jq
 	@echo "Formatting Python files with black.."
 	cd whisper && uv run black .
+	@echo "Formatting Claude settings.."
+	jq -S --indent 2 . claude/settings.json > claude/settings.json.tmp && mv claude/settings.json.tmp claude/settings.json
+
+install-hooks: # Wire tools/git-hooks/ into this repo via core.hooksPath
+	@echo "Setting core.hooksPath to tools/git-hooks.."
+	git config core.hooksPath tools/git-hooks
 
 check-secret: # Check file or directory for secrets using gitleaks (Usage: make check-secret TARGET=path)
 	@if [ -z "$(TARGET)" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,8 @@ lint: # Run shellcheck on shell files and ruff on Python files
 	cd whisper && uv run ruff check . && cd ..
 	@echo "Checking package files are alphabetically sorted.."
 	./tools/check-package-sort.sh
+	@echo "Checking Claude theme is pinned.."
+	./tools/check-claude-theme.sh
 
 format: # Format Python files with black
 	@echo "Formatting Python files with black.."

--- a/agent-skills/screenshot/SKILL.md
+++ b/agent-skills/screenshot/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: screenshot
+description: Read the most recent screenshot(s) the user took. Use when the user references "the screenshot I took", "my latest screenshot", "look at the screenshot", "the 3 screenshots I just took", "a few screenshots", or similar phrasings that imply opening their most recent screen capture(s) without specifying a path.
+argument-hint: "[count]"
+---
+
+Resolve the user's most recent screenshot(s) and Read them.
+
+## 1. Determine count
+
+How many of the newest screenshots to read:
+
+- If `$ARGUMENTS` contains a number, use that.
+- Otherwise, parse the user's message:
+  - Explicit number ("the 3 screenshots", "last 2") → that number.
+  - "a couple" → 2.
+  - "a few", "several", "some" → 3.
+  - Singular ("the screenshot", "my latest screenshot") or unstated → 1.
+
+## 2. Resolve the directory
+
+In order:
+
+1. If `$SCREENSHOT_DIR` is set, use it. If it's set but the path doesn't exist, say so and stop — do not fall back, that would hide typos.
+2. Otherwise, pick by Platform from your environment context:
+   - `darwin` → `~/Desktop`
+   - `linux` → `~/Pictures`
+
+## 3. Find the newest N images
+
+```bash
+find "$dir" -maxdepth 1 -type f \( -iname '*.png' -o -iname '*.jpg' -o -iname '*.jpeg' -o -iname '*.gif' -o -iname '*.webp' \) -print0 \
+  | xargs -0 ls -t \
+  | head -n "$count"
+```
+
+If the directory exists but has no matching images, say so and stop. If the user asked for N but only M < N exist, read what's there and mention the shortfall.
+
+## 4. Read each file
+
+Use the Read tool on each path (newest first). Briefly state filename + mtime for each so the user can sanity-check you grabbed the right shots.

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,6 +1,71 @@
 {
+  "alwaysThinkingEnabled": true,
+  "effortLevel": "medium",
+  "enabledPlugins": {
+    "clangd-lsp@claude-plugins-official": false,
+    "code-review@claude-plugins-official": true,
+    "code-simplifier@claude-plugins-official": true,
+    "commit-commands@claude-plugins-official": true,
+    "lua-lsp@claude-plugins-official": true,
+    "playwright@claude-plugins-official": true,
+    "pr-review-toolkit@claude-plugins-official": true,
+    "pyright-lsp@claude-plugins-official": true,
+    "typescript-lsp@claude-plugins-official": true
+  },
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "hooks": {
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "command": "$HOME/.claude/bin/claude-notify-sfx.py play ringaling 90",
+            "type": "command"
+          }
+        ],
+        "matcher": "permission_prompt"
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "jq -r '.tool_input.command' | grep -qE '(^|[ ;&|])(rm|rmdir)( |$)' && printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Use trashit instead of rm/rmdir — moves items to trash for safety\"}}' || true",
+            "type": "command"
+          },
+          {
+            "command": "jq -r '.tool_input.command' | grep -qE '(^|[ ;&|()`$])gh( |$)' && printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"GitHub identity: @thavelick. @me works in gh CLI filters (--assignee @me, --author @me, search syntax) but NOT in @-mentions, commit co-author trailers, URLs, or most GraphQL login args — use @thavelick literally there.\"}}' || true",
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash"
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "command": "$HOME/.claude/bin/claude-notify-sfx.py play dading 60",
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "command": "$HOME/.claude/bin/claude-notify-sfx.py start",
+            "type": "command"
+          },
+          {
+            "command": "jq -r '.prompt // \"\"' | grep -qiE '(qcopy|qpaste|clipboard|copy (me|that|this)|paste (me|that|this))' && printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"UserPromptSubmit\",\"additionalContext\":\"Use qcopy and qpaste for the user clipboard (cross-platform pbcopy/pbpaste). Only applies to clipboard ops — ignore if the request is about copying files or pasting code into a file.\"}}' || true",
+            "type": "command"
+          }
+        ]
+      }
+    ]
   },
   "permissions": {
     "allow": [
@@ -29,87 +94,22 @@
       "Bash(sed *)",
       "Bash(for *)"
     ],
-    "deny": [
-      "Bash(sudo *)",
-      "Bash(rm *)",
-      "Bash(rm -*)"
-    ],
     "ask": [
       "Edit(.claude/settings.json)",
       "Write(.claude/settings.json)",
       "Bash(gh pr merge*)",
       "Bash(gh repo delete*)"
     ],
-    "defaultMode": "auto"
-  },
-  "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "jq -r '.tool_input.command' | grep -qE '(^|[ ;&|])(rm|rmdir)( |$)' && printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Use trashit instead of rm/rmdir — moves items to trash for safety\"}}' || true"
-          },
-          {
-            "type": "command",
-            "command": "jq -r '.tool_input.command' | grep -qE '(^|[ ;&|()`$])gh( |$)' && printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"GitHub identity: @thavelick. @me works in gh CLI filters (--assignee @me, --author @me, search syntax) but NOT in @-mentions, commit co-author trailers, URLs, or most GraphQL login args — use @thavelick literally there.\"}}' || true"
-          }
-        ]
-      }
-    ],
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "$HOME/.claude/bin/claude-notify-sfx.py start"
-          },
-          {
-            "type": "command",
-            "command": "jq -r '.prompt // \"\"' | grep -qiE '(qcopy|qpaste|clipboard|copy (me|that|this)|paste (me|that|this))' && printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"UserPromptSubmit\",\"additionalContext\":\"Use qcopy and qpaste for the user clipboard (cross-platform pbcopy/pbpaste). Only applies to clipboard ops — ignore if the request is about copying files or pasting code into a file.\"}}' || true"
-          }
-        ]
-      }
-    ],
-    "Notification": [
-      {
-        "matcher": "permission_prompt",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "$HOME/.claude/bin/claude-notify-sfx.py play ringaling 90"
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "$HOME/.claude/bin/claude-notify-sfx.py play dading 60"
-          }
-        ]
-      }
+    "defaultMode": "auto",
+    "deny": [
+      "Bash(sudo *)",
+      "Bash(rm *)",
+      "Bash(rm -*)"
     ]
   },
-  "enabledPlugins": {
-    "code-simplifier@claude-plugins-official": true,
-    "commit-commands@claude-plugins-official": true,
-    "typescript-lsp@claude-plugins-official": true,
-    "pyright-lsp@claude-plugins-official": true,
-    "playwright@claude-plugins-official": true,
-    "pr-review-toolkit@claude-plugins-official": true,
-    "code-review@claude-plugins-official": true,
-    "lua-lsp@claude-plugins-official": true,
-    "clangd-lsp@claude-plugins-official": false
-  },
-  "alwaysThinkingEnabled": true,
-  "effortLevel": "medium",
   "promptSuggestionEnabled": false,
+  "skipAutoPermissionPrompt": true,
   "skipDangerousModePermissionPrompt": true,
-  "theme": "dark",
   "teammateMode": "tmux",
-  "skipAutoPermissionPrompt": true
+  "theme": "dark"
 }

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -3,7 +3,6 @@
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
   "permissions": {
-    "defaultMode": "auto",
     "allow": [
       "Bash(git *)",
       "Bash(gh *)",
@@ -40,7 +39,8 @@
       "Write(.claude/settings.json)",
       "Bash(gh pr merge*)",
       "Bash(gh repo delete*)"
-    ]
+    ],
+    "defaultMode": "auto"
   },
   "hooks": {
     "PreToolUse": [
@@ -107,8 +107,9 @@
   },
   "alwaysThinkingEnabled": true,
   "effortLevel": "medium",
+  "promptSuggestionEnabled": false,
   "skipDangerousModePermissionPrompt": true,
-  "skipAutoPermissionPrompt": true,
+  "theme": "dark",
   "teammateMode": "tmux",
-  "promptSuggestionEnabled": false
+  "skipAutoPermissionPrompt": true
 }

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -110,6 +110,5 @@
   "skipDangerousModePermissionPrompt": true,
   "skipAutoPermissionPrompt": true,
   "teammateMode": "tmux",
-  "theme": "light",
   "promptSuggestionEnabled": false
 }

--- a/tools/check-claude-settings-format.sh
+++ b/tools/check-claude-settings-format.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# Fails if claude/settings.json is not in canonical sorted/indented form.
+# `make format` will fix it.
+
+set -eu
+
+file="claude/settings.json"
+tmp=$(mktemp)
+trap 'rm -f "$tmp"' EXIT
+
+jq -S --indent 2 . "$file" > "$tmp"
+
+if ! diff -q "$file" "$tmp" >/dev/null 2>&1; then
+  printf '\033[1;31m%s is not in canonical format. Run: make format\033[0m\n' "$file" >&2
+  exit 1
+fi

--- a/tools/check-claude-theme.sh
+++ b/tools/check-claude-theme.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Guard against /theme accidentally flipping the tracked theme value.
+# Claude Code's /theme writes to ~/.claude/settings.json, which is a
+# symlink to claude/settings.json in this repo — so changing the theme
+# at runtime dirties the repo. We pin it to "dark" here so any drift
+# fails lint and prompts a manual revert.
+
+set -eu
+
+settings="claude/settings.json"
+expected="dark"
+
+actual=$(jq -r '.theme // "missing"' "$settings")
+
+if [ "$actual" != "$expected" ]; then
+  printf '\033[1;31m%s has theme=%s, expected %s.\033[0m\n' "$settings" "$actual" "$expected" >&2
+  printf 'Did /theme rewrite the file? Run: git checkout -- %s\n' "$settings" >&2
+  exit 1
+fi

--- a/tools/git-hooks/pre-commit
+++ b/tools/git-hooks/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Wired up by `make install-hooks` (sets core.hooksPath).
+set -e
+exec make lint


### PR DESCRIPTION
## Summary

- New `screenshot` agent-skill: auto-invokes when I reference my latest screenshot(s) ("the screenshot I took", "the 3 screenshots I just took"). Resolves the directory from `$SCREENSHOT_DIR`, else `~/Desktop` on darwin or `~/Pictures` on linux, and reads the newest N images.
- Pin `theme: dark` in `claude/settings.json` and add a lint check (`tools/check-claude-theme.sh`) so `/theme` rewrites can't silently flip it. Claude Code has no user-scoped `settings.local.json`, so pinning + guarding is the cleanest fix.

## Test plan

- [x] `make lint` passes
- [ ] On macOS: take a few screenshots, then "look at the screenshot I took" → newest image read
- [ ] On macOS: "look at the 3 screenshots I just took" → newest 3 read
- [ ] On macOS: `/screenshot 2` → newest 2 read
- [ ] `SCREENSHOT_DIR=/tmp` override works
- [ ] `SCREENSHOT_DIR=/nonexistent` reports error and stops (no silent fallback)
- [ ] Linux verification deferred until next time on Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)