### PR TITLE
Update laptop references from Surface Pro to ThinkPad X1 Carbon

### DIFF
--- a/river/README.md
+++ b/river/README.md
@@ -62,7 +62,7 @@ This directory contains the configuration for the River Wayland compositor.
 
 ### System Controls
 
-#### Media Keys (Surface Pro/Laptop)
+#### Media Keys (ThinkPad X1 Carbon 5th Gen)
 - **Volume Up/Down/Mute** - Hardware media keys
 - **Brightness Up/Down** - Hardware function keys
 - **Play/Pause/Next/Previous** - Hardware media keys

--- a/river/init
+++ b/river/init
@@ -4,7 +4,7 @@ set -e
 mod="Mod1"
 for mode in normal locked
 do
-  # arch/surfacepro
+  # arch/thinkpad-x1-carbon-5th-gen
   riverctl map $mode None XF86AudioRaiseVolume  spawn 'pamixer -i 5'
   riverctl map $mode None XF86AudioLowerVolume  spawn 'pamixer -d 5'
   riverctl map $mode None XF86AudioMute         spawn 'pamixer --toggle-mute'


### PR DESCRIPTION
## Summary
- Update river media keys section header and init comment to reflect current hardware (ThinkPad X1 Carbon 5th Gen)

## Test plan
- [x] grep confirms no remaining stale Surface Pro references

🤖 Generated with [Claude Code](https://claude.com/claude-code)