### PR TITLE
Enable frontend-design plugin in Claude settings

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -6,6 +6,7 @@
     "code-review@claude-plugins-official": true,
     "code-simplifier@claude-plugins-official": true,
     "commit-commands@claude-plugins-official": true,
+    "frontend-design@claude-plugins-official": true,
     "lua-lsp@claude-plugins-official": true,
     "playwright@claude-plugins-official": true,
     "pr-review-toolkit@claude-plugins-official": true,


### PR DESCRIPTION
## Summary
- Enable the `frontend-design@claude-plugins-official` plugin in `claude/settings.json`

## Test plan
- [x] `make lint` passes (settings remain jq-sorted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)