### PR TITLE
Switch ALE Python linter/fixer from pylint+black to ruff

### DIFF
--- a/vim/init.lua
+++ b/vim/init.lua
@@ -122,9 +122,9 @@ vim.o.clipboard = 'unnamedplus'
 -- ALE linters and fixers configuration
 vim.g.ale_linters = {
   html = {'tidy'},
-  python = {'pylint'}
+  python = {'ruff'}
 }
-vim.g.ale_fixers = { python = {'black'} }
+vim.g.ale_fixers = { python = {'ruff', 'ruff_format'} }
 vim.g.ale_fix_on_save = 1
 
 -- Function to trim trailing whitespace


### PR DESCRIPTION
## Summary
- Replace `pylint` with `ruff` as the ALE linter for Python
- Replace `black` with `ruff` + `ruff_format` as the ALE fixers

## Why
`pylint` was running without the project venv, causing false "unable to import" errors for packages like `duckdb` that are only in the venv. `ruff` resolves correctly and `ruff_format` replaces `black` for on-save formatting.

## Test plan
- [ ] Open a Python file in Neovim — no false import errors
- [ ] Introduce a lint error (e.g. unused import) — ALE flags it
- [ ] Add extra whitespace and save — `ruff_format` fixes it on save

🤖 Generated with [Claude Code](https://claude.com/claude-code)