### PR TITLE
Add playback CLI for cross-platform pause/play

### DIFF
--- a/bin/playback
+++ b/bin/playback
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "-h" ]] || [[ "${1:-}" == "--help" ]]; then
+    cat <<EOF
+Usage: playback --play | --pause
+
+Idempotently play or pause whatever media is currently active
+(YouTube in a browser, Jellyfin, Spotify, mpv, etc.).
+
+  --play   Ensure playback is running (no-op if already playing)
+  --pause  Ensure playback is paused  (no-op if already paused)
+
+If nothing is currently playing, exits 0 silently.
+
+Backends (in preference order):
+  - playerctl       (Linux, MPRIS)
+  - nowplaying-cli  (macOS, MediaRemote private framework)
+EOF
+    exit 0
+fi
+
+case "${1:-}" in
+    --play)  action=play ;;
+    --pause) action=pause ;;
+    "")
+        echo "Usage: playback --play | --pause" >&2
+        exit 1
+        ;;
+    *)
+        echo "playback: unknown argument: $1" >&2
+        echo "Usage: playback --play | --pause" >&2
+        exit 1
+        ;;
+esac
+
+if hash playerctl 2>/dev/null; then
+    playerctl --no-messages "$action" 2>/dev/null || true
+elif hash nowplaying-cli 2>/dev/null; then
+    nowplaying-cli "$action" >/dev/null 2>&1 || true
+else
+    echo "playback: no supported backend found (need playerctl or nowplaying-cli)" >&2
+    exit 1
+fi

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -21,6 +21,10 @@
       {
         "hooks": [
           {
+            "command": "playback --pause",
+            "type": "command"
+          },
+          {
             "command": "$HOME/.claude/bin/claude-notify-sfx.py play ringaling 90",
             "type": "command"
           }
@@ -46,6 +50,10 @@
     "Stop": [
       {
         "hooks": [
+          {
+            "command": "playback --pause",
+            "type": "command"
+          },
           {
             "command": "$HOME/.claude/bin/claude-notify-sfx.py play dading 60",
             "type": "command"

--- a/mac/packages
+++ b/mac/packages
@@ -48,6 +48,7 @@ neovim
 ninja
 nmap
 node
+nowplaying-cli
 ollama
 openvpn
 pandoc


### PR DESCRIPTION
## Summary
- New `bin/playback` script: idempotent `--play` / `--pause` for whatever media is currently active (YouTube in browser, Jellyfin, Spotify, mpv, etc.)
- Linux backend: `playerctl` (already installed, already used in river bindings)
- Mac backend: `nowplaying-cli` (added to `mac/packages`); uses MediaRemote private framework so apps see real Play/Pause commands rather than a blind toggle
- Silent exit 0 when nothing is playing; exit 1 with error if no backend is installed

## Test plan
- [x] `make format` and `make lint` pass
- [x] `playback --pause` / `--play` exercised on Linux
- [x] `playback`, `playback --nope`, `playback --help` behave correctly
- [ ] Manual QA on Mac with Safari/YouTube, Music.app, Spotify

🤖 Generated with [Claude Code](https://claude.com/claude-code)