### PR TITLE
Add playback --pause-distractions that skips Jellyfin Desktop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,33 +67,10 @@ test-all: # Run both minimal and core tests
 	make test-core
 
 lint: # Run shellcheck on shell files and ruff on Python files
-	@echo "Running shellcheck on shell files.."
-	@./tools/list-shell-files.sh | xargs shellcheck || { \
-		echo; \
-		echo "shellcheck found issues — run 'make lint-fix' to auto-apply fixes (review the diff before committing)"; \
-		exit 1; \
-	}
-	@echo "Running ruff on Python files.."
-	cd whisper && uv run ruff check . && cd ..
-	@echo "Checking package files are alphabetically sorted.."
-	./tools/check-package-sort.sh
-	@echo "Checking Claude theme is pinned.."
-	./tools/check-claude-theme.sh
-	@echo "Checking Claude settings are formatted.."
-	./tools/check-claude-settings-format.sh
+	@./tools/lint.sh
 
 lint-fix: # Auto-apply shellcheck fixes via 'shellcheck -f diff | patch'
-	@echo "Applying shellcheck auto-fixes.."
-	@./tools/list-shell-files.sh | while IFS= read -r f; do \
-		diff=$$(shellcheck -f diff "$$f" 2>/dev/null || true); \
-		if [ -n "$$diff" ]; then \
-			echo "Patching $$f"; \
-			printf '%s\n' "$$diff" | patch -p0 "$$f"; \
-		fi; \
-	done
-	@echo
-	@echo "Re-running shellcheck.."
-	@./tools/list-shell-files.sh | xargs shellcheck
+	@./tools/lint-fix.sh
 
 format: # Format Python files with ruff and JSON files with jq
 	@echo "Formatting Python files with ruff.."

--- a/Makefile
+++ b/Makefile
@@ -68,11 +68,11 @@ test-all: # Run both minimal and core tests
 
 lint: # Run shellcheck on shell files and ruff on Python files
 	@echo "Running shellcheck on shell files.."
-	@if ! ./tools/list-shell-files.sh | xargs shellcheck; then
-		echo
-		echo "shellcheck found issues — run 'make lint-fix' to auto-apply fixes (review the diff before committing)"
-		exit 1
-	fi
+	@./tools/list-shell-files.sh | xargs shellcheck || { \
+		echo; \
+		echo "shellcheck found issues — run 'make lint-fix' to auto-apply fixes (review the diff before committing)"; \
+		exit 1; \
+	}
 	@echo "Running ruff on Python files.."
 	cd whisper && uv run ruff check . && cd ..
 	@echo "Checking package files are alphabetically sorted.."
@@ -84,12 +84,12 @@ lint: # Run shellcheck on shell files and ruff on Python files
 
 lint-fix: # Auto-apply shellcheck fixes via 'shellcheck -f diff | patch'
 	@echo "Applying shellcheck auto-fixes.."
-	@./tools/list-shell-files.sh | while IFS= read -r f; do
-		diff=$$(shellcheck -f diff "$$f" 2>/dev/null || true)
-		if [ -n "$$diff" ]; then
-			echo "Patching $$f"
-			printf '%s\n' "$$diff" | patch -p0 "$$f"
-		fi
+	@./tools/list-shell-files.sh | while IFS= read -r f; do \
+		diff=$$(shellcheck -f diff "$$f" 2>/dev/null || true); \
+		if [ -n "$$diff" ]; then \
+			echo "Patching $$f"; \
+			printf '%s\n' "$$diff" | patch -p0 "$$f"; \
+		fi; \
 	done
 	@echo
 	@echo "Re-running shellcheck.."

--- a/bin/playback
+++ b/bin/playback
@@ -46,7 +46,7 @@ if hash playerctl 2>/dev/null; then
     playerctl --no-messages "$action" 2>/dev/null || true
 elif hash nowplaying-cli 2>/dev/null; then
     if [[ "$skip_jellyfin" == true ]]; then
-        current=$(nowplaying-cli get bundleIdentifier 2>/dev/null || true)
+        current=$(nowplaying-cli get clientBundleIdentifier 2>/dev/null || true)
         if [[ "$current" == "org.jellyfin.jellyfin-desktop" ]]; then
             exit 0
         fi

--- a/bin/playback
+++ b/bin/playback
@@ -1,15 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ "${1:-}" == "-h" ]] || [[ "${1:-}" == "--help" ]]; then
+usage() {
     cat <<EOF
-Usage: playback --play | --pause
+Usage: playback --play | --pause | --pause-distractions
 
 Idempotently play or pause whatever media is currently active
 (YouTube in a browser, Jellyfin, Spotify, mpv, etc.).
 
-  --play   Ensure playback is running (no-op if already playing)
-  --pause  Ensure playback is paused  (no-op if already paused)
+  --play                Ensure playback is running (no-op if already playing)
+  --pause               Ensure playback is paused  (no-op if already paused)
+  --pause-distractions  Like --pause, but leave Jellyfin Desktop alone
 
 If nothing is currently playing, exits 0 silently.
 
@@ -17,26 +18,39 @@ Backends (in preference order):
   - playerctl       (Linux, MPRIS)
   - nowplaying-cli  (macOS, MediaRemote private framework)
 EOF
+}
+
+if [[ "${1:-}" == "-h" ]] || [[ "${1:-}" == "--help" ]]; then
+    usage
     exit 0
 fi
 
+skip_jellyfin=false
 case "${1:-}" in
     --play)  action=play ;;
     --pause) action=pause ;;
+    --pause-distractions) action=pause; skip_jellyfin=true ;;
     "")
-        echo "Usage: playback --play | --pause" >&2
+        usage >&2
         exit 1
         ;;
     *)
         echo "playback: unknown argument: $1" >&2
-        echo "Usage: playback --play | --pause" >&2
+        usage >&2
         exit 1
         ;;
 esac
 
 if hash playerctl 2>/dev/null; then
+    # TODO: honor skip_jellyfin on Linux once we pick a desktop client there
     playerctl --no-messages "$action" 2>/dev/null || true
 elif hash nowplaying-cli 2>/dev/null; then
+    if [[ "$skip_jellyfin" == true ]]; then
+        current=$(nowplaying-cli get bundleIdentifier 2>/dev/null || true)
+        if [[ "$current" == "org.jellyfin.jellyfin-desktop" ]]; then
+            exit 0
+        fi
+    fi
     nowplaying-cli "$action" >/dev/null 2>&1 || true
 else
     echo "playback: no supported backend found (need playerctl or nowplaying-cli)" >&2

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -21,7 +21,7 @@
       {
         "hooks": [
           {
-            "command": "playback --pause",
+            "command": "playback --pause-distractions",
             "type": "command"
           },
           {
@@ -51,7 +51,7 @@
       {
         "hooks": [
           {
-            "command": "playback --pause",
+            "command": "playback --pause-distractions",
             "type": "command"
           },
           {

--- a/tools/lint-fix.sh
+++ b/tools/lint-fix.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+echo "Applying shellcheck auto-fixes.."
+./tools/list-shell-files.sh | while IFS= read -r f; do
+    diff=$(shellcheck -f diff "$f" 2>/dev/null || true)
+    if [ -n "$diff" ]; then
+        echo "Patching $f"
+        printf '%s\n' "$diff" | patch -p0 "$f"
+    fi
+done
+
+echo
+echo "Re-running shellcheck.."
+./tools/list-shell-files.sh | xargs shellcheck

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+echo "Running shellcheck on shell files.."
+if ! ./tools/list-shell-files.sh | xargs shellcheck; then
+    echo
+    echo "shellcheck found issues — run 'make lint-fix' to auto-apply fixes (review the diff before committing)"
+    exit 1
+fi
+
+echo "Running ruff on Python files.."
+(cd whisper && uv run ruff check .)
+
+echo "Checking package files are alphabetically sorted.."
+./tools/check-package-sort.sh
+
+echo "Checking Claude theme is pinned.."
+./tools/check-claude-theme.sh
+
+echo "Checking Claude settings are formatted.."
+./tools/check-claude-settings-format.sh


### PR DESCRIPTION
## Summary
- New `playback --pause-distractions` flag pauses media unless Jellyfin Desktop holds the macOS Now Playing slot, so Claude's Stop / permission_prompt hooks don't yank music away mid-song.
- `--pause` / `--play` are unchanged.
- Linux carve-out is a TODO until we pick a desktop Jellyfin client there.
- Drive-by: rewrite `lint` and `lint-fix` Makefile recipes with backslash continuations so they work under macOS's stock GNU Make 3.81 (which silently ignores `.ONESHELL`).

## Test plan
- [x] `make lint` passes
- [ ] With Jellyfin Desktop playing music: `playback --pause-distractions` is a no-op; music keeps playing
- [ ] With a browser tab playing YouTube: `playback --pause-distractions` pauses it
- [ ] Trigger a Claude permission prompt / Stop hook while music is playing in Jellyfin Desktop — music keeps going
- [ ] `playback --pause` still pauses Jellyfin Desktop unconditionally

🤖 Generated with [Claude Code](https://claude.com/claude-code)