### PR TITLE
Cap nowplaying-cli calls at 2s in playback

### DIFF
--- a/bin/playback
+++ b/bin/playback
@@ -47,17 +47,17 @@ if hash playerctl 2>/dev/null; then
 elif hash nowplaying-cli 2>/dev/null; then
     # MediaRemote can wedge — cap each call so we never block Claude's Stop hook.
     if hash timeout 2>/dev/null; then
-        np() { timeout 2 nowplaying-cli "$@"; }
+        nowplaying() { timeout 2 nowplaying-cli "$@"; }
     else
-        np() { nowplaying-cli "$@"; }
+        nowplaying() { nowplaying-cli "$@"; }
     fi
     if [[ "$skip_jellyfin" == true ]]; then
-        current=$(np get clientBundleIdentifier 2>/dev/null || true)
+        current=$(nowplaying get clientBundleIdentifier 2>/dev/null || true)
         if [[ "$current" == "org.jellyfin.jellyfin-desktop" ]]; then
             exit 0
         fi
     fi
-    np "$action" >/dev/null 2>&1 || true
+    nowplaying "$action" >/dev/null 2>&1 || true
 else
     echo "playback: no supported backend found (need playerctl or nowplaying-cli)" >&2
     exit 1

--- a/bin/playback
+++ b/bin/playback
@@ -45,13 +45,19 @@ if hash playerctl 2>/dev/null; then
     # TODO: honor skip_jellyfin on Linux once we pick a desktop client there
     playerctl --no-messages "$action" 2>/dev/null || true
 elif hash nowplaying-cli 2>/dev/null; then
+    # MediaRemote can wedge — cap each call so we never block Claude's Stop hook.
+    if hash timeout 2>/dev/null; then
+        np() { timeout 2 nowplaying-cli "$@"; }
+    else
+        np() { nowplaying-cli "$@"; }
+    fi
     if [[ "$skip_jellyfin" == true ]]; then
-        current=$(nowplaying-cli get clientBundleIdentifier 2>/dev/null || true)
+        current=$(np get clientBundleIdentifier 2>/dev/null || true)
         if [[ "$current" == "org.jellyfin.jellyfin-desktop" ]]; then
             exit 0
         fi
     fi
-    nowplaying-cli "$action" >/dev/null 2>&1 || true
+    np "$action" >/dev/null 2>&1 || true
 else
     echo "playback: no supported backend found (need playerctl or nowplaying-cli)" >&2
     exit 1

--- a/bin/playback
+++ b/bin/playback
@@ -46,18 +46,15 @@ if hash playerctl 2>/dev/null; then
     playerctl --no-messages "$action" 2>/dev/null || true
 elif hash nowplaying-cli 2>/dev/null; then
     # MediaRemote can wedge — cap each call so we never block Claude's Stop hook.
-    if hash timeout 2>/dev/null; then
-        nowplaying() { timeout 2 nowplaying-cli "$@"; }
-    else
-        nowplaying() { nowplaying-cli "$@"; }
-    fi
+    timeout_prefix=""
+    hash timeout 2>/dev/null && timeout_prefix="timeout 2"
     if [[ "$skip_jellyfin" == true ]]; then
-        current=$(nowplaying get clientBundleIdentifier 2>/dev/null || true)
+        current=$($timeout_prefix nowplaying-cli get clientBundleIdentifier 2>/dev/null || true)
         if [[ "$current" == "org.jellyfin.jellyfin-desktop" ]]; then
             exit 0
         fi
     fi
-    nowplaying "$action" >/dev/null 2>&1 || true
+    $timeout_prefix nowplaying-cli "$action" >/dev/null 2>&1 || true
 else
     echo "playback: no supported backend found (need playerctl or nowplaying-cli)" >&2
     exit 1


### PR DESCRIPTION
## Summary
- The macOS MediaRemote framework occasionally wedges, which makes `nowplaying-cli get` / `pause` block indefinitely. That's been hanging Claude's Stop hook (`playback --pause-distractions`) on @thavelick's machine.
- Wrap each `nowplaying-cli` invocation in `timeout 2` so a wedged MediaRemote can't block the caller. Falls back to running `nowplaying-cli` unwrapped if `timeout` isn't on PATH (stock macOS without coreutils).

## Test plan
- [x] `make lint` passes
- [x] `playback --pause-distractions` still works normally
- [ ] Confirm Claude Stop hook no longer hangs when MediaRemote is wedged

🤖 Generated with [Claude Code](https://claude.com/claude-code)