### PR TITLE
Disable telemetry and exclude eXoDOS from backups

### DIFF
--- a/arch/backup_excludes.txt
+++ b/arch/backup_excludes.txt
@@ -6,6 +6,7 @@
 /home/tristan/.cargo/*
 /home/tristan/Downloads/*
 /home/tristan/Games/eXoDemoScene/*
+/home/tristan/Games/eXoDOS/*
 /home/tristan/Movies/*
 /home/tristan/go/*
 /home/tristan/.gradle/*

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -14,7 +14,8 @@
     "typescript-lsp@claude-plugins-official": true
   },
   "env": {
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
+    "DISABLE_TELEMETRY": "1"
   },
   "hooks": {
     "Notification": [


### PR DESCRIPTION
## Summary
- Set `DISABLE_TELEMETRY=1` in Claude settings
- Add `~/Games/eXoDOS/*` to backup excludes

🤖 Generated with [Claude Code](https://claude.com/claude-code)