### PR TITLE
Move keyboard layout to keyd; exclude flatpak from backups

### DIFF
--- a/arch/backup_excludes.txt
+++ b/arch/backup_excludes.txt
@@ -10,6 +10,7 @@
 /home/tristan/Movies/*
 /home/tristan/go/*
 /home/tristan/.gradle/*
+/home/tristan/.local/share/flatpak/*
 /home/tristan/.ollama/models/*
 /home/tristan/kiwix/*.zim
 /home/tristan/.local/share/Zeal/*

--- a/zsh/core.zsh
+++ b/zsh/core.zsh
@@ -72,9 +72,9 @@ if [[ "$(get_os_type)" == "macos" && -n "$SSH_CONNECTION" ]] && ! security show-
     read -q "?Keychain is locked. Unlock it? [y/N] " && echo && security unlock-keychain ~/Library/Keychains/login.keychain-db || echo
 fi
 
-# Keyboard layout (only matters on systems that use it)
-export XKB_DEFAULT_LAYOUT="us(colemak)"
-export XKB_DEFAULT_OPTIONS=ctrl:nocaps
+# Keyboard layout (Colemak + Caps→Ctrl) is now owned by keyd at the evdev level
+# so it reaches raw-input apps (SDL 1.2 DOSBox / eXoDOS) too. Display server is
+# left plain US; do not set XKB_DEFAULT_LAYOUT/OPTIONS here or the layers stack.
 
 # Help system
 export HELPDIR=/usr/share/zsh/"${ZSH_VERSION}"/help


### PR DESCRIPTION
## Summary
- Add `~/.local/share/flatpak/*` to backup excludes
- Move Colemak + Caps→Ctrl ownership to keyd at the evdev level so it reaches raw-input apps (SDL 1.2 DOSBox / eXoDOS); drop the now-redundant `XKB_DEFAULT_LAYOUT`/`XKB_DEFAULT_OPTIONS` exports (leaving them set would stack the layers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)