### PR TITLE
Don't wrap exodos in a terminal from the launcher

### DIFF
--- a/river/launcher.sh
+++ b/river/launcher.sh
@@ -14,7 +14,7 @@ echo "$program_to_launch" >> "$HOME/.cache/launcher_history"
 
 # run the program they chose, in a terminal if needed
 desktop_file=$(grep -lE "Exec=.*$program_to_launch" /usr/share/applications/*.desktop)
-not_terminal_apps="firefox|grim-partial|cli_splits_launcher"
+not_terminal_apps="firefox|grim-partial|cli_splits_launcher|exodos"
 
 [ -z "$desktop_file" ] || grep -qE "Terminal=true" "$desktop_file" && [[ ! "$program_to_launch" =~ $not_terminal_apps ]] && program_to_launch="foot $(which "$program_to_launch")"
 # [ -z "$desktop_file" ] || grep -qE "Terminal=true" "$desktop_file" && program_to_launch="foot $(which "$program_to_launch")"


### PR DESCRIPTION
## Summary
- exodos worked from a terminal but not from the river launcher (Alt-based program launcher)
- `launcher.sh` wraps any program without a `.desktop` file in a `foot` terminal, assuming it's a CLI tool
- exodos has no `.desktop` file, so it got `foot /home/tristan/.local/bin/exodos` — the terminal exited as soon as `exogui` backgrounded itself, killing the GUI
- Added `exodos` to `not_terminal_apps` so the launcher spawns it directly

## Test plan
- Launch exodos from the program launcher and confirm exogui stays running

🤖 Generated with [Claude Code](https://claude.com/claude-code)