### PR TITLE
Add dMagnetic PKGBUILD and foot window padding

### DIFF
--- a/arch/pkgbuilds/dmagnetic/PKGBUILD
+++ b/arch/pkgbuilds/dmagnetic/PKGBUILD
@@ -1,0 +1,41 @@
+# Maintainer: Tristan Havelick <tristan@havelick.com>
+
+pkgname=dmagnetic
+pkgver=0.37
+pkgrel=1
+pkgdesc="Terminal Magnetic Scrolls interpreter with ANSI/sixel/UTF graphics"
+arch=('x86_64' 'aarch64')
+url="https://www.dettus.net/dMagnetic/"
+license=('BSD-2-Clause')
+depends=('glibc')
+# Upstream's install target already strips the binary (install -s), so there are
+# no debug symbols to split — skip the (empty) debug package and its gdb warning.
+options=('!debug')
+# make/gcc come from base-devel, which makepkg assumes is installed.
+source=("https://www.dettus.net/dMagnetic/dMagnetic_$pkgver.tar.bz2")
+sha256sums=('ad812bb515bc972e23930d643d5abeaed971d550768b1b3f371bd0f72c3c2e89')
+
+build() {
+  cd "$srcdir/dMagnetic_$pkgver"
+  # Pure C, no external deps. The Makefile uses CFLAGS?=, so makepkg's
+  # exported build flags are honored; it only appends -Wall.
+  make
+}
+
+check() {
+  cd "$srcdir/dMagnetic_$pkgver"
+  # Upstream's post-compilation render tests against bundled testcode/minitest.mag.
+  # Default SHA256_CMD is BSD's "sha256"; on Linux it's "sha256sum".
+  make SHA256_CMD="sha256sum" check
+}
+
+package() {
+  cd "$srcdir/dMagnetic_$pkgver"
+  # Upstream conflates DESTDIR/PREFIX (MYPREFIX=$(DESTDIR)), so DESTDIR is the
+  # install root rather than a staging prefix. Point it at $pkgdir/usr to land
+  # bin/, share/man/, and share/games/ under /usr.
+  make DESTDIR="$pkgdir/usr" install
+
+  # Also drop the license where Arch expects it.
+  install -Dm644 LICENSE.txt "$pkgdir/usr/share/licenses/$pkgname/LICENSE.txt"
+}

--- a/foot/foot.ini
+++ b/foot/foot.ini
@@ -1,5 +1,6 @@
 [main]
 include=~/.local/share/foot/foot-theme.ini
+pad=20x20 center
 font=MesloLGS Nerd Font Mono:size=11.5
 font-bold=MesloLGS Nerd Font Mono:style=Bold:size=11.5
 font-italic=MesloLGS Nerd Font Mono:style=Italic:size=11.5


### PR DESCRIPTION
## Summary
- New `arch/pkgbuilds/dmagnetic/PKGBUILD`: builds the dMagnetic 0.37 Magnetic Scrolls interpreter from the official dettus.net source tarball (sha256-pinned), pure C with only `glibc` at runtime. `check()` runs upstream's bundled render self-tests; installs to a clean FHS tree and disables the empty debug split (binary is pre-stripped).
- `foot/foot.ini`: add `pad=20x20 center` so terminals (and the game) get a margin instead of painting flush to the window edge.

## Testing
- `makepkg` builds a single clean `dmagnetic-0.37-1-x86_64.pkg.tar.zst`; all 9 upstream self-checks pass.
- Installed and verified: `pacman -Qkk dmagnetic` → 0 altered files; `dMagnetic -version` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)