### PR TITLE
Add IFM (Interactive Fiction Mapper) PKGBUILD

### DIFF
--- a/arch/pkgbuilds/ifm/PKGBUILD
+++ b/arch/pkgbuilds/ifm/PKGBUILD
@@ -1,0 +1,50 @@
+# Maintainer: Tristan Havelick <tristan@havelick.com>
+
+pkgname=ifm
+pkgver=5.5
+pkgrel=1
+pkgdesc="Interactive Fiction Mapper: a language and CLI tool for mapping and solving IF games"
+arch=('x86_64' 'aarch64')
+url="https://ifm.readthedocs.io/"
+license=('GPL-2.0-only')
+depends=('glibc')
+# configure hard-requires a Python interpreter (AM_PATH_PYTHON). flex/bison are
+# NOT needed: this release tarball ships the pre-generated lexer/parser
+# (src/ifm-scan.c, src/ifm-parse.c) and the configure script, so we only run
+# ./configure && make. base-devel provides make/gcc.
+makedepends=('python')
+# The IF Archive release tarball is self-contained (bundles configure and the
+# flex/bison output); the upstream source lives at https://git.sr.ht/~zondo/ifm
+source=("https://ifarchive.org/if-archive/mapping-tools/$pkgname-$pkgver.tar.gz")
+sha256sums=('e6140fd48c98a8b0c64b97fdada78f6ff3d3b25241d036fdced738257cb1ad39')
+
+build() {
+  cd "$srcdir/$pkgname-$pkgver"
+  # 5.5 predates upstream's GCC-15 fix and uses K&R-style unprototyped function
+  # pointers. GCC 15 defaults to C23, where () means (void), turning those into
+  # hard errors. -std=gnu17 restores the older semantics; append it so makepkg's
+  # hardening/optimization CFLAGS are preserved.
+  CFLAGS="$CFLAGS -std=gnu17" ./configure --prefix=/usr
+  # Build only the core program (src/ also builds the bundled libfig/libvars).
+  # The doc/ subdir builds HTML via sphinx and its install ignores DESTDIR, and
+  # progs/ builds optional perl/tk helper scripts -- skip both for a clean CLI
+  # package. The user guide is hosted at https://ifm.readthedocs.io/.
+  make -C src
+}
+
+check() {
+  cd "$srcdir/$pkgname-$pkgver"
+  # Upstream's automake test suite: 41 tests comparing ifm output to .exp files.
+  make -C tests check
+}
+
+package() {
+  cd "$srcdir/$pkgname-$pkgver"
+  # Install the binary (src), the runtime library data in /usr/share/ifm (lib),
+  # and the pre-built man page (man). All three honor DESTDIR.
+  make -C src install DESTDIR="$pkgdir"
+  make -C lib install DESTDIR="$pkgdir"
+  make -C man install DESTDIR="$pkgdir"
+
+  install -Dm644 COPYING "$pkgdir/usr/share/licenses/$pkgname/COPYING"
+}

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,8 +1,83 @@
 {
+  "alwaysThinkingEnabled": true,
+  "effortLevel": "medium",
+  "enabledPlugins": {
+    "clangd-lsp@claude-plugins-official": false,
+    "code-review@claude-plugins-official": true,
+    "code-simplifier@claude-plugins-official": true,
+    "commit-commands@claude-plugins-official": true,
+    "frontend-design@claude-plugins-official": true,
+    "lua-lsp@claude-plugins-official": true,
+    "playwright@claude-plugins-official": true,
+    "pr-review-toolkit@claude-plugins-official": true,
+    "pyright-lsp@claude-plugins-official": true,
+    "typescript-lsp@claude-plugins-official": true
+  },
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "DISABLE_TELEMETRY": "1"
   },
+  "hooks": {
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "command": "playback --pause-distractions",
+            "type": "command"
+          },
+          {
+            "command": "$HOME/.claude/bin/claude-notify-sfx.py play ringaling 90",
+            "type": "command"
+          }
+        ],
+        "matcher": "permission_prompt"
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "jq -r '.tool_input.command' | grep -qE '(^|[ ;&|])(rm|rmdir)( |$)' && printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Use trashit instead of rm/rmdir — moves items to trash for safety\"}}' || true",
+            "type": "command"
+          },
+          {
+            "command": "jq -r '.tool_input.command' | grep -qE '(^|[ ;&|()`$])gh( |$)' && printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"GitHub identity: @thavelick. @me works in gh CLI filters (--assignee @me, --author @me, search syntax) but NOT in @-mentions, commit co-author trailers, URLs, or most GraphQL login args — use @thavelick literally there.\"}}' || true",
+            "type": "command"
+          }
+        ],
+        "matcher": "Bash"
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "command": "playback --pause-distractions",
+            "type": "command"
+          },
+          {
+            "command": "$HOME/.claude/bin/claude-notify-sfx.py play dading 60",
+            "type": "command"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "command": "$HOME/.claude/bin/claude-notify-sfx.py start",
+            "type": "command"
+          },
+          {
+            "command": "jq -r '.prompt // \"\"' | grep -qiE '(qcopy|qpaste|clipboard|copy (me|that|this)|paste (me|that|this))' && printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"UserPromptSubmit\",\"additionalContext\":\"Use qcopy and qpaste for the user clipboard (cross-platform pbcopy/pbpaste). Only applies to clipboard ops — ignore if the request is about copying files or pasting code into a file.\"}}' || true",
+            "type": "command"
+          }
+        ]
+      }
+    ]
+  },
+  "model": "opus",
   "permissions": {
     "allow": [
       "Bash(git *)",
@@ -30,97 +105,22 @@
       "Bash(sed *)",
       "Bash(for *)"
     ],
-    "deny": [
-      "Bash(sudo *)",
-      "Bash(rm *)",
-      "Bash(rm -*)"
-    ],
     "ask": [
       "Edit(.claude/settings.json)",
       "Write(.claude/settings.json)",
       "Bash(gh pr merge*)",
       "Bash(gh repo delete*)"
     ],
-    "defaultMode": "auto"
-  },
-  "model": "opus",
-  "hooks": {
-    "Notification": [
-      {
-        "matcher": "permission_prompt",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "playback --pause-distractions"
-          },
-          {
-            "type": "command",
-            "command": "$HOME/.claude/bin/claude-notify-sfx.py play ringaling 90"
-          }
-        ]
-      }
-    ],
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "jq -r '.tool_input.command' | grep -qE '(^|[ ;&|])(rm|rmdir)( |$)' && printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Use trashit instead of rm/rmdir — moves items to trash for safety\"}}' || true"
-          },
-          {
-            "type": "command",
-            "command": "jq -r '.tool_input.command' | grep -qE '(^|[ ;&|()`$])gh( |$)' && printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"GitHub identity: @thavelick. @me works in gh CLI filters (--assignee @me, --author @me, search syntax) but NOT in @-mentions, commit co-author trailers, URLs, or most GraphQL login args — use @thavelick literally there.\"}}' || true"
-          }
-        ]
-      }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "playback --pause-distractions"
-          },
-          {
-            "type": "command",
-            "command": "$HOME/.claude/bin/claude-notify-sfx.py play dading 60"
-          }
-        ]
-      }
-    ],
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "$HOME/.claude/bin/claude-notify-sfx.py start"
-          },
-          {
-            "type": "command",
-            "command": "jq -r '.prompt // \"\"' | grep -qiE '(qcopy|qpaste|clipboard|copy (me|that|this)|paste (me|that|this))' && printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"UserPromptSubmit\",\"additionalContext\":\"Use qcopy and qpaste for the user clipboard (cross-platform pbcopy/pbpaste). Only applies to clipboard ops — ignore if the request is about copying files or pasting code into a file.\"}}' || true"
-          }
-        ]
-      }
+    "defaultMode": "auto",
+    "deny": [
+      "Bash(sudo *)",
+      "Bash(rm *)",
+      "Bash(rm -*)"
     ]
   },
-  "enabledPlugins": {
-    "clangd-lsp@claude-plugins-official": false,
-    "code-review@claude-plugins-official": true,
-    "code-simplifier@claude-plugins-official": true,
-    "commit-commands@claude-plugins-official": true,
-    "frontend-design@claude-plugins-official": true,
-    "lua-lsp@claude-plugins-official": true,
-    "playwright@claude-plugins-official": true,
-    "pr-review-toolkit@claude-plugins-official": true,
-    "pyright-lsp@claude-plugins-official": true,
-    "typescript-lsp@claude-plugins-official": true
-  },
-  "alwaysThinkingEnabled": true,
-  "effortLevel": "medium",
   "promptSuggestionEnabled": false,
+  "skipAutoPermissionPrompt": true,
   "skipDangerousModePermissionPrompt": true,
-  "theme": "auto",
   "teammateMode": "tmux",
-  "skipAutoPermissionPrompt": true
+  "theme": "auto"
 }

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -1,83 +1,8 @@
 {
-  "alwaysThinkingEnabled": true,
-  "effortLevel": "medium",
-  "enabledPlugins": {
-    "clangd-lsp@claude-plugins-official": false,
-    "code-review@claude-plugins-official": true,
-    "code-simplifier@claude-plugins-official": true,
-    "commit-commands@claude-plugins-official": true,
-    "frontend-design@claude-plugins-official": true,
-    "lua-lsp@claude-plugins-official": true,
-    "playwright@claude-plugins-official": true,
-    "pr-review-toolkit@claude-plugins-official": true,
-    "pyright-lsp@claude-plugins-official": true,
-    "typescript-lsp@claude-plugins-official": true
-  },
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
     "DISABLE_TELEMETRY": "1"
   },
-  "hooks": {
-    "Notification": [
-      {
-        "hooks": [
-          {
-            "command": "playback --pause-distractions",
-            "type": "command"
-          },
-          {
-            "command": "$HOME/.claude/bin/claude-notify-sfx.py play ringaling 90",
-            "type": "command"
-          }
-        ],
-        "matcher": "permission_prompt"
-      }
-    ],
-    "PreToolUse": [
-      {
-        "hooks": [
-          {
-            "command": "jq -r '.tool_input.command' | grep -qE '(^|[ ;&|])(rm|rmdir)( |$)' && printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Use trashit instead of rm/rmdir — moves items to trash for safety\"}}' || true",
-            "type": "command"
-          },
-          {
-            "command": "jq -r '.tool_input.command' | grep -qE '(^|[ ;&|()`$])gh( |$)' && printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"GitHub identity: @thavelick. @me works in gh CLI filters (--assignee @me, --author @me, search syntax) but NOT in @-mentions, commit co-author trailers, URLs, or most GraphQL login args — use @thavelick literally there.\"}}' || true",
-            "type": "command"
-          }
-        ],
-        "matcher": "Bash"
-      }
-    ],
-    "Stop": [
-      {
-        "hooks": [
-          {
-            "command": "playback --pause-distractions",
-            "type": "command"
-          },
-          {
-            "command": "$HOME/.claude/bin/claude-notify-sfx.py play dading 60",
-            "type": "command"
-          }
-        ]
-      }
-    ],
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "command": "$HOME/.claude/bin/claude-notify-sfx.py start",
-            "type": "command"
-          },
-          {
-            "command": "jq -r '.prompt // \"\"' | grep -qiE '(qcopy|qpaste|clipboard|copy (me|that|this)|paste (me|that|this))' && printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"UserPromptSubmit\",\"additionalContext\":\"Use qcopy and qpaste for the user clipboard (cross-platform pbcopy/pbpaste). Only applies to clipboard ops — ignore if the request is about copying files or pasting code into a file.\"}}' || true",
-            "type": "command"
-          }
-        ]
-      }
-    ]
-  },
-  "model": "opus",
   "permissions": {
     "allow": [
       "Bash(git *)",
@@ -105,22 +30,97 @@
       "Bash(sed *)",
       "Bash(for *)"
     ],
+    "deny": [
+      "Bash(sudo *)",
+      "Bash(rm *)",
+      "Bash(rm -*)"
+    ],
     "ask": [
       "Edit(.claude/settings.json)",
       "Write(.claude/settings.json)",
       "Bash(gh pr merge*)",
       "Bash(gh repo delete*)"
     ],
-    "defaultMode": "auto",
-    "deny": [
-      "Bash(sudo *)",
-      "Bash(rm *)",
-      "Bash(rm -*)"
+    "defaultMode": "auto"
+  },
+  "model": "opus",
+  "hooks": {
+    "Notification": [
+      {
+        "matcher": "permission_prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "playback --pause-distractions"
+          },
+          {
+            "type": "command",
+            "command": "$HOME/.claude/bin/claude-notify-sfx.py play ringaling 90"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.command' | grep -qE '(^|[ ;&|])(rm|rmdir)( |$)' && printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Use trashit instead of rm/rmdir — moves items to trash for safety\"}}' || true"
+          },
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.command' | grep -qE '(^|[ ;&|()`$])gh( |$)' && printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"additionalContext\":\"GitHub identity: @thavelick. @me works in gh CLI filters (--assignee @me, --author @me, search syntax) but NOT in @-mentions, commit co-author trailers, URLs, or most GraphQL login args — use @thavelick literally there.\"}}' || true"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "playback --pause-distractions"
+          },
+          {
+            "type": "command",
+            "command": "$HOME/.claude/bin/claude-notify-sfx.py play dading 60"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$HOME/.claude/bin/claude-notify-sfx.py start"
+          },
+          {
+            "type": "command",
+            "command": "jq -r '.prompt // \"\"' | grep -qiE '(qcopy|qpaste|clipboard|copy (me|that|this)|paste (me|that|this))' && printf '%s' '{\"hookSpecificOutput\":{\"hookEventName\":\"UserPromptSubmit\",\"additionalContext\":\"Use qcopy and qpaste for the user clipboard (cross-platform pbcopy/pbpaste). Only applies to clipboard ops — ignore if the request is about copying files or pasting code into a file.\"}}' || true"
+          }
+        ]
+      }
     ]
   },
+  "enabledPlugins": {
+    "clangd-lsp@claude-plugins-official": false,
+    "code-review@claude-plugins-official": true,
+    "code-simplifier@claude-plugins-official": true,
+    "commit-commands@claude-plugins-official": true,
+    "frontend-design@claude-plugins-official": true,
+    "lua-lsp@claude-plugins-official": true,
+    "playwright@claude-plugins-official": true,
+    "pr-review-toolkit@claude-plugins-official": true,
+    "pyright-lsp@claude-plugins-official": true,
+    "typescript-lsp@claude-plugins-official": true
+  },
+  "alwaysThinkingEnabled": true,
+  "effortLevel": "medium",
   "promptSuggestionEnabled": false,
-  "skipAutoPermissionPrompt": true,
   "skipDangerousModePermissionPrompt": true,
+  "theme": "auto",
   "teammateMode": "tmux",
-  "theme": "auto"
+  "skipAutoPermissionPrompt": true
 }

--- a/vim/ftdetect/ifm.vim
+++ b/vim/ftdetect/ifm.vim
@@ -1,0 +1,1 @@
+au BufRead,BufNewFile *.ifm set filetype=ifm

--- a/vim/setup.sh
+++ b/vim/setup.sh
@@ -7,6 +7,8 @@ echo "$packer_path"
 mkdir -p "$HOME/.config/nvim"
 ln -svf "$DOTFILES_HOME/vim/init.lua" "$HOME/.config/nvim/init.lua"
 ln -svf "$DOTFILES_HOME/vim/lua" "$HOME/.config/nvim/lua"
+ln -svf "$DOTFILES_HOME/vim/syntax" "$HOME/.config/nvim/syntax"
+ln -svf "$DOTFILES_HOME/vim/ftdetect" "$HOME/.config/nvim/ftdetect"
 
 # symlink .vim
 ln -svf "$DOTFILES_HOME/vim/.vim" "$HOME"

--- a/vim/syntax/ifm.vim
+++ b/vim/syntax/ifm.vim
@@ -1,0 +1,143 @@
+" IFM syntax file
+" Language: Interactive Fiction Mapper
+" Maintainer: Dave Chapeskie <dchapes@ddm.wox.org>
+"
+" Note:  This is my first attempt at doing vim syntax highlighting,
+"        if there is a better way of doing any of this please e-mail me.
+" Note:  This is for version 5.2 of IFM.
+
+" Remove any old syntax stuff hanging around
+syntax clear
+
+" Catch keywords in the wrong spot
+syntax keyword ifmError contained title map require room item task link join
+
+" IFM statements
+" TODO: doesn't complain when there is something betweem the keyword and the
+"       string
+" TODO: IFM2.0 and above supports changing existing objects by leaving out
+"	the string and using the tag, the tag doesn't get hightlighted using
+"       ifmId yet.
+syntax region ifmTitleStatement	end=";" matchgroup=ifmStatement start="\<title\>" contains=ifmError,ifmComment,ifmString
+syntax region ifmMapStatement	end=";" matchgroup=ifmStatement start="\<map\>" contains=ifmError,ifmComment,ifmString
+syntax region ifmRequireStatement end=";" matchgroup=ifmStatement start="\<require\>" contains=ifmError,ifmComment,ifmReal
+syntax region ifmRoomStatement	end=";" matchgroup=ifmStatement start="\<room\>" contains=ifmError,ifmComment,ifmString,ifmRoomOpt,ifmTagOpt,ifmDirFromOpt,ifmExitOpt,ifmScoreOpt,ifmGoOpt,ifmLengthOpt
+syntax region ifmItemStatement	end=";" matchgroup=ifmStatement start="\<item\>" contains=ifmError,ifmComment,ifmString,ifmItemOpt,ifmTagOpt,ifmInOpt,ifmScoreOpt
+syntax region ifmTaskStatement	end=";" matchgroup=ifmStatement start="\<task\>" contains=ifmError,ifmComment,ifmString,ifmTaskOpt,ifmTagOpt,ifmInOpt,ifmScoreOpt
+syntax region ifmLinkStatement	end=";" matchgroup=ifmStatement start="\<link\>" contains=ifmError,ifmComment,ifmString,ifmLinkOpt,ifmTagOpt,ifmDirOpt,ifmGoOpt,ifmLengthOpt
+syntax region ifmJoinStatement	end=";" matchgroup=ifmStatement start="\<join\>" contains=ifmError,ifmComment,ifmString,ifmJoinOpt,ifmTagOpt,ifmDirOpt,ifmGoOpt,ifmLengthOpt
+syntax region ifmStyleStatement	end=";" matchgroup=ifmStatement start="\<style\>" contains=ifmId,ifmComment
+syntax region ifmEndStyleStatement	end=";" matchgroup=ifmStatement start="\<endstyle\>" contains=ifmId,ifmComment
+
+" Comments
+syntax match ifmComment "#.*" contains=ifmTodo
+syntax keyword ifmTodo	contained TODO XXX
+
+" Arguments of options which we want highlighted
+syntax keyword ifmGoDir contained out in up down
+" TODO: ifmString doesn't handle "testStr\\" correctly...
+syntax region ifmString	contained start=+"+ skip=+\\"+ end=+"+
+syntax match ifmId	contained "[a-zA-Z][a-zA-Z0-9_]*"
+syntax match ifmInteger	contained "[0-9]\+"
+syntax match ifmReal	contained "[0-9]\+\.[0-9]\+"
+
+" The options which the above arguments are part of
+syntax region ifmTagOpt	contained end="\<\S*\>" matchgroup=ifmKeyword start="\<tag\>" contains=ifmId keepend
+syntax region ifmScoreOpt contained end="\<[0-9]*\>" matchgroup=ifmKeyword start="\<score\>" contains=ifmInteger keepend
+syntax region ifmLengthOpt contained end="\<[0-9]*\>" matchgroup=ifmKeyword start="\<length\>" contains=ifmInteger keepend
+syntax region ifmGoOpt	contained end="\<\S*\>" matchgroup=ifmKeyword start="\<go\>" contains=ifmGoDir keepend
+syntax region ifmFromOpt contained end="\<\S*\>" matchgroup=ifmKeyword start="\<from\>" contains=ifmId keepend
+syntax region ifmInOpt contained end="\<\S*\>" matchgroup=ifmKeyword start="\<in\>" contains=ifmId keepend
+
+syntax keyword ifmExitOpt	contained exit			skipwhite skipempty nextgroup=ifmExitDir
+syntax keyword ifmExitDir	contained nw n ne w e sw s se	skipwhite skipempty nextgroup=ifmExitDir
+syntax keyword ifmExitDir contained northwest north northeast west east southwest south southeast skipwhite skipempty nextgroup=ifmExitDir
+
+syntax keyword ifmDirFromOpt	contained dir			skipwhite skipempty nextgroup=ifmDirFrom
+syntax keyword ifmDirFrom	contained nw n ne w e sw s se	skipwhite skipempty nextgroup=ifmDirFrom,ifmDirFromInt,ifmFromOpt
+syntax keyword ifmDirFrom contained northwest north northeast west east southwest south southeast skipwhite skipempty nextgroup=ifmExitDir
+syntax match ifmDirFromInt	contained "[0-9]\+"		skipwhite skipempty nextgroup=ifmDirFrom,ifmFromOpt
+
+
+" Other options:
+"    These options take arguments but we don't hightlight them
+"    TODO: "in/after last" should have the word 'last' highlighted as a
+"    constant, similarily for tasks "in any" should have 'any' highlighted
+"    TODO: 'it' and 'them' should be highlighted (e.g. task "xx" need xx drop it)
+"    TODO: IFM2.0 added things like "leave all except ID" which should be
+"    highlighted.
+"    TODO: 'cmd from' and 'cmd to' should be hightlighted instead of just 'cmd'
+"    TODO: IFM5.0 added "keep with/until ID [ID...]" for items; 'with'/'until'
+"    should be highlighted.
+syntax keyword ifmRoomOpt contained link join note need after before leave cmd
+syntax keyword ifmRoomOpt contained style
+syntax keyword ifmItemOpt contained note need after before style
+syntax keyword ifmTaskOpt contained cmd note need after follow do get give lose
+syntax keyword ifmTaskOpt contained drop goto style
+syntax keyword ifmLinkOpt contained to cmd need after before leave style
+syntax keyword ifmJoinOpt contained to cmd need after before leave style
+"    These options don't have arguments
+syntax keyword ifmRoomOpt contained start oneway finish nodrop nolink nopath
+syntax keyword ifmItemOpt contained hidden keep ignore lost finish "given [obsolete]
+syntax keyword ifmTaskOpt contained safe ignore finish
+syntax keyword ifmLinkOpt contained oneway hidden nopath
+syntax keyword ifmJoinOpt contained oneway hidden nopath
+
+
+" IFM variable assignment
+" [Format.]Ident = Integer|Real|String|"undef" ["in style" Id] ;
+" TODO: handle "undef" keyword and "in style" clause
+syntax region ifmEqInt contained end=";" matchgroup=ifmStatement start="=" contains=ifmInteger
+syntax region ifmEqReal contained end=";" matchgroup=ifmStatement start="=" contains=ifmInteger,ifmReal
+syntax region ifmEqString contained end=";" matchgroup=ifmStatement start="=" contains=ifmString
+
+syntax keyword ifmIntIdent item_text_fontsize link_dashed link_line_width link_spline link_text_fontsize map_text_fontsize page_rotate room_border_dashed room_border_width room_exit_width room_text_fontsize show_border show_page_border show_items show_tags show_title show_page_title title_fontsize page_title_fontsize map_title_fontsize fit_page show_map_title map_section_spacing show_map_border show_joins keep_unused_items all_tasks_safe solver_messages task_graph_rooms task_graph_orphans skipwhite skipempty nextgroup=ifmEqInt
+syntax keyword ifmRealIdent canvas_height canvas_width font_scale link_arrow_size page_height page_margin page_width room_height room_shadow_xoff room_shadow_yoff room_size room_width map_canvas_width map_canvas_height skipwhite skipempty nextgroup=ifmEqReal
+syntax keyword ifmStringIdent canvas_background_colour colour_file item_text_colour item_text_font item_text_fontdef link_colour link_inout_string link_text_colour link_text_font link_text_fontdef link_updown_string map_text_colour map_text_font page_background_colour page_border_colour page_size prolog_file room_border_colour room_colour room_exit_colour room_shadow_colour room_text_colour room_text_font room_text_fontdef title_colour page_title_colour map_title_colour title_font page_title_font map_title_font map_border_colour map_background_colour join_format task_graph_attr task_graph_node task_graph_link skipwhite skipempty nextgroup=ifmEqString
+
+syntax keyword ifmFormat ps tk text raw rec skipwhite skipempty nextgroup=ifmIntIdent,ifmRealIdent,ifmStringIdent
+
+
+" Synchronization.
+" Look backwards for a ';' but ignore any that occur in comments or
+" strings.  Stop after going back 250 lines without finding a ';'
+syntax sync match ifmSyncRoutine grouphere NONE ";"
+syntax sync match ifmNoSyncComment "#.*"
+syntax sync region ifmNoSyncString start=+"+ skip=+\\"+ end=+"+
+syntax sync maxlines=250
+
+
+if !exists("did_ifm_syntax_inits")
+  let did_ifm_syntax_inits = 1
+  " The default methods for highlighting.  Can be overridden later
+  highlight link ifmStatement	Statement
+  highlight link ifmRoomOpt	ifmKeyword
+  highlight link ifmItemOpt	ifmKeyword
+  highlight link ifmTaskOpt	ifmKeyword
+  highlight link ifmLinkOpt	ifmKeyword
+  highlight link ifmJoinOpt	ifmKeyword
+  highlight link ifmExitOpt	ifmKeyword
+  highlight link ifmDirFromOpt	ifmKeyword
+  highlight link ifmFromOpt	ifmKeyword
+  highlight link ifmKeyword	Type
+  highlight link ifmGoDir	Constant
+  highlight link ifmDirFromInt	ifmDirFrom
+  highlight link ifmDirFrom	Constant
+  highlight link ifmExitDir	Constant
+  highlight link ifmInteger	Number
+  highlight link ifmReal	Number
+  highlight link ifmError	Error
+  highlight link ifmString	String
+  highlight link ifmComment	Comment
+  highlight link ifmTodo	Todo
+  highlight	 ifmId		term=bold cterm=bold gui=bold
+  highlight link ifmFormat	Type
+  highlight link ifmIntIdent	ifmIdent
+  highlight link ifmRealIdent	ifmIdent
+  highlight link ifmStringIdent	ifmIdent
+  highlight link ifmIdent	Identifier
+endif
+
+let current_syntax = "ifm"
+
+" ifm: ts=8


### PR DESCRIPTION
Adds a from-source PKGBUILD for [IFM](https://ifm.readthedocs.io/) (Interactive Fiction Mapper) 5.5 by Glenn Hutchings, at `arch/pkgbuilds/ifm/PKGBUILD`.

## Research findings
- **Source:** No Linux prebuilt binary exists upstream (only a Windows MinGW build). Built from the IF Archive source release `ifm-5.5.tar.gz`, sha256-pinned. Upstream dev repo: https://git.sr.ht/~zondo/ifm
- **Version:** 5.5 (30 Jul 2022) is the latest tagged release; 5.6 is unreleased in master.
- **License:** GPL-2.0-only (`COPYING`), installed to `/usr/share/licenses/ifm/`.
- **Build system:** autotools. The release tarball is self-contained — it ships `configure` *and* the flex/bison output (`ifm-scan.c`, `ifm-parse.c`) — so no autotools/flex/bison are needed, just `./configure && make`. Only `python` (configure's `AM_PATH_PYTHON`) is a non-base-devel makedep.
- **Deps:** binary links only `libm`/`libc` → `depends=('glibc')`.

## Notable decisions
- **`-std=gnu17`:** 5.5 predates upstream's GCC-15 fix and uses K&R-style unprototyped function pointers. GCC 15 defaults to C23 (where `()` means `(void)`), turning these into hard compile errors. Appending `-std=gnu17` to makepkg's CFLAGS restores the old semantics while preserving hardening flags.
- **Scoped to `src`/`lib`/`man`:** skips the sphinx HTML docs (online at readthedocs) whose `doc/` install ignores `DESTDIR` and would write to `/usr/doc`, plus the optional perl/tk helper scripts — keeping output deterministic with no perl/tk runtime deps.
- No `options=('!debug')`: upstream does not pre-strip, so makepkg's normal debug split applies.

## Validation
- `makepkg -f` builds clean in a temp dir; `ifm-debug` splits correctly.
- `check()` runs the upstream suite: **41/41 pass**.
- Installed via `arch/pkgbuilds/install.sh ifm`; `pacman -Qkk ifm` → 0 altered files.
- Binary runs (`IFM version 5.5`) and produces correct text/PS map output from a bundled test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)