### PR TITLE
Add Nextcloud sync-needed prompt indicator

### DIFF
--- a/bin/nextcloud-sync
+++ b/bin/nextcloud-sync
@@ -27,3 +27,7 @@ fi
 mkdir -p ~/nextcloud
 
 rclone bisync nextcloud: ~/nextcloud --exclude "transmission/**" $RESYNC_FLAG
+
+# Sync succeeded (set -e would have aborted otherwise), so clear the
+# prompt's "sync needed" sentinel that nextcloud-sync-check maintains.
+rm -f "${XDG_CACHE_HOME:-$HOME/.cache}/nextcloud-sync-needed"

--- a/bin/nextcloud-sync-check
+++ b/bin/nextcloud-sync-check
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -u
+set -o pipefail
+
+if [[ "${1:-}" == "-h" ]] || [[ "${1:-}" == "--help" ]]; then
+    cat <<EOF
+Usage: nextcloud-sync-check
+
+Check whether ~/nextcloud is out of sync with the nextcloud: remote and record
+the result in a sentinel file for the shell prompt to read.
+
+  - differences found    -> create the sentinel (sync needed)
+  - no differences       -> remove the sentinel (in sync)
+  - remote unreachable    -> leave the sentinel untouched (avoid false flags)
+
+Sentinel file: \${XDG_CACHE_HOME:-~/.cache}/nextcloud-sync-needed
+EOF
+    exit 0
+fi
+
+CACHE_FILE="${XDG_CACHE_HOME:-$HOME/.cache}/nextcloud-sync-needed"
+
+output=$(rclone check nextcloud: ~/nextcloud --exclude "transmission/**" 2>&1)
+
+# Pull the count out of rclone's "N differences found" summary line. This is
+# absent when the remote is unreachable, which lets us leave the sentinel alone
+# instead of falsely flagging a sync.
+count=$(printf '%s\n' "$output" | grep -oE '[0-9]+ differences found' | head -1 | grep -oE '^[0-9]+')
+
+if [[ -z "$count" ]]; then
+    # Could not determine sync state (network/remote error); leave sentinel as-is.
+    exit 0
+elif [[ "$count" -gt 0 ]]; then
+    mkdir -p "$(dirname "$CACHE_FILE")"
+    touch "$CACHE_FILE"
+else
+    rm -f "$CACHE_FILE"
+fi

--- a/mac/com.havelick.nextcloud-sync-check.plist.template
+++ b/mac/com.havelick.nextcloud-sync-check.plist.template
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.havelick.nextcloud-sync-check</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__SCRIPT__</string>
+    </array>
+
+    <!-- launchd jobs get a minimal PATH; add Homebrew so rclone is found. -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+
+    <!-- Check every 30 minutes, and once shortly after login. -->
+    <key>StartInterval</key>
+    <integer>1800</integer>
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>StandardErrorPath</key>
+    <string>__LOG__</string>
+</dict>
+</plist>

--- a/mac/setup.sh
+++ b/mac/setup.sh
@@ -47,3 +47,15 @@ ln -svf "$DOTFILES_HOME/mac/DefaultKeyBinding.dict" ~/Library/KeyBindings/Defaul
 
 # Restart preferences daemon to apply changes
 /System/Library/PrivateFrameworks/SystemAdministration.framework/Resources/activateSettings -u
+
+# Install the Nextcloud sync-needed check as a launchd agent (macOS equivalent
+# of the systemd timer used on Linux). Runs bin/nextcloud-sync-check every 30
+# minutes to maintain the ~/.cache/nextcloud-sync-needed sentinel the prompt reads.
+mkdir -p ~/Library/LaunchAgents ~/.cache
+NEXTCLOUD_AGENT=~/Library/LaunchAgents/com.havelick.nextcloud-sync-check.plist
+sed \
+  -e "s|__SCRIPT__|$DOTFILES_HOME/bin/nextcloud-sync-check|" \
+  -e "s|__LOG__|$HOME/.cache/nextcloud-sync-check.log|" \
+  "$DOTFILES_HOME/mac/com.havelick.nextcloud-sync-check.plist.template" > "$NEXTCLOUD_AGENT"
+launchctl unload "$NEXTCLOUD_AGENT" 2>/dev/null || true
+launchctl load -w "$NEXTCLOUD_AGENT"

--- a/systemd/setup.sh
+++ b/systemd/setup.sh
@@ -7,12 +7,16 @@ mkdir -p "$HOME/.config/systemd/user"
 # Symlink systemd user services
 ln -svf "$DOTFILES_HOME/systemd/user/monitor-hotplug.service" "$HOME/.config/systemd/user/monitor-hotplug.service"
 ln -svf "$DOTFILES_HOME/systemd/user/kiwix.service" "$HOME/.config/systemd/user/kiwix.service"
+ln -svf "$DOTFILES_HOME/systemd/user/nextcloud-sync-check.service" "$HOME/.config/systemd/user/nextcloud-sync-check.service"
+ln -svf "$DOTFILES_HOME/systemd/user/nextcloud-sync-check.timer" "$HOME/.config/systemd/user/nextcloud-sync-check.timer"
 
 # Reload systemd and enable services
 systemctl --user daemon-reload
 systemctl --user enable monitor-hotplug.service
 systemctl --user enable kiwix.service
+systemctl --user enable nextcloud-sync-check.timer
 
 # Start services if not already running
 systemctl --user is-active --quiet monitor-hotplug.service || systemctl --user start monitor-hotplug.service
 systemctl --user is-active --quiet kiwix.service || systemctl --user start kiwix.service
+systemctl --user is-active --quiet nextcloud-sync-check.timer || systemctl --user start nextcloud-sync-check.timer

--- a/systemd/user/nextcloud-sync-check.service
+++ b/systemd/user/nextcloud-sync-check.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Check whether Nextcloud needs a sync
+
+[Service]
+Type=oneshot
+ExecStart=%h/Projects/dotfiles/bin/nextcloud-sync-check

--- a/systemd/user/nextcloud-sync-check.timer
+++ b/systemd/user/nextcloud-sync-check.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Check whether Nextcloud needs a sync every 30 minutes
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=30min
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/zsh/prompt.zsh
+++ b/zsh/prompt.zsh
@@ -109,6 +109,15 @@ docker_indicator() {
     fi
 }
 
+# Nextcloud sync indicator: shows ☁️ when nextcloud-sync-check has found the
+# local ~/nextcloud out of sync with the remote (sentinel maintained by the
+# nextcloud-sync-check timer, cleared when nextcloud-sync runs).
+nextcloud_indicator() {
+    if [ -f "${XDG_CACHE_HOME:-$HOME/.cache}/nextcloud-sync-needed" ]; then
+        echo " ☁️"
+    fi
+}
+
 hostname_indicator() {
     if is_ssh; then
         echo "%m:"
@@ -119,4 +128,4 @@ hostname_indicator() {
 setopt prompt_subst
 
 # Set the prompt
-PROMPT='${prompt_error}${prompt_time}$(hostname_indicator)%~ $(distro_icon)$(docker_indicator) ${vcs_info_msg_0_}% ➜ '
+PROMPT='${prompt_error}${prompt_time}$(hostname_indicator)%~ $(distro_icon)$(docker_indicator)$(nextcloud_indicator) ${vcs_info_msg_0_}% ➜ '


### PR DESCRIPTION
## Summary

Adds a background check + prompt indicator so I can tell at a glance whether `nextcloud-sync` needs to be run.

- `bin/nextcloud-sync-check` — runs `rclone check`, parses the `N differences found` line and touches/removes a `~/.cache/nextcloud-sync-needed` sentinel. If the remote is unreachable (no summary line), it leaves the sentinel untouched to avoid false flags.
- `bin/nextcloud-sync` — clears the sentinel after a successful `bisync`.
- `systemd/user/nextcloud-sync-check.{service,timer}` — oneshot service + 30-min timer (`Persistent=true` catches up after suspend), wired into `systemd/setup.sh`.
- `zsh/prompt.zsh` — `nextcloud_indicator` shows ☁️ when the sentinel exists, added to `PROMPT` outside the `~/Projects` git block so it shows everywhere.

## Activation

```bash
cd ~/Projects/dotfiles && DOTFILES_HOME=$PWD sh systemd/setup.sh
exec zsh
```

## Notes

- LibreOffice `.~lock.*#` files currently count as differences; can add an exclude to the check if that noise is unwanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)