### PR TITLE
Add Google Drive sync via rclone

### DIFF
--- a/bin/gdrive-sync
+++ b/bin/gdrive-sync
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -e
+set -u
+set -o pipefail
+
+if [[ "${1:-}" == "-h" ]] || [[ "${1:-}" == "--help" ]]; then
+    cat <<EOF
+Usage: gdrive-sync [--resync]
+
+Sync Google Drive using rclone:
+  - Bidirectional sync of My Drive (gdrive:) to ~/gdrive.
+    Native Google Docs/Sheets/Slides are skipped here; bisync can't
+    round-trip them safely.
+  - One-way, read-only mirror of shared-with-me files (gdrive-shared:)
+    to ~/gdrive-shared. Native Docs are exported as .docx/.xlsx/etc.
+    Local edits and deletions there are never pushed back and will be
+    overwritten on the next sync.
+
+Options:
+  --resync    Force resync of the bidirectional pair (required for
+              first run or after errors)
+
+Examples:
+  gdrive-sync           - Normal sync
+  gdrive-sync --resync  - Force resync from scratch
+EOF
+    exit 0
+fi
+
+RESYNC_FLAG=""
+if [[ "${1:-}" == "--resync" ]]; then
+    RESYNC_FLAG="--resync"
+fi
+
+mkdir -p ~/gdrive ~/gdrive-shared
+
+rclone bisync gdrive: ~/gdrive --drive-skip-gdocs $RESYNC_FLAG
+
+rclone sync gdrive-shared: ~/gdrive-shared

--- a/rclone/rclone.conf.template
+++ b/rclone/rclone.conf.template
@@ -19,3 +19,14 @@ vendor = nextcloud
 user = {{RCLONE_NEXTCLOUD_USER}}
 pass = {{RCLONE_NEXTCLOUD_PASS}}
 
+[gdrive]
+type = drive
+scope = drive
+token = {{RCLONE_GDRIVE_TOKEN}}
+
+[gdrive-shared]
+type = drive
+scope = drive
+shared_with_me = true
+token = {{RCLONE_GDRIVE_TOKEN}}
+

--- a/rclone/secrets.json
+++ b/rclone/secrets.json
@@ -9,7 +9,8 @@
         "system-backup:key": "RCLONE_B2_KEY",
         "nextcloud:pass": "RCLONE_NEXTCLOUD_PASS",
         "nextcloud:url": "RCLONE_NEXTCLOUD_URL",
-        "nextcloud:user": "RCLONE_NEXTCLOUD_USER"
+        "nextcloud:user": "RCLONE_NEXTCLOUD_USER",
+        "gdrive:token": "RCLONE_GDRIVE_TOKEN"
       }
     }
   ]


### PR DESCRIPTION
## Summary
- Add `gdrive` (My Drive) and `gdrive-shared` (shared-with-me) remotes to the rclone config template, both sharing one OAuth token stored in KeePassXC as `gdrive:token` and rendered via `update-secrets`
- Add `bin/gdrive-sync`, modeled on `nextcloud-sync`: bidirectional bisync of My Drive to `~/gdrive` (native Google Docs skipped — bisync can't round-trip them), plus a one-way read-only mirror of shared-with-me files to `~/gdrive-shared` (one-way so local deletions can never delete other people's shared files)

## Test plan
- [x] `update-secrets rclone` regenerates a working config including both new remotes
- [x] `rclone lsf gdrive:` and `rclone lsf gdrive-shared:` list expected files
- [x] `gdrive-sync --resync` completes the initial sync; subsequent `gdrive-sync` runs cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)