### PR TITLE
Fix shrunken Nerd Font icons in waybar battery/pulseaudio

### DIFF
--- a/waybar/style.css
+++ b/waybar/style.css
@@ -3,6 +3,10 @@
 	font-family: "monospace";
 }
 
+#battery, #pulseaudio {
+	font-family: "MesloLGS Nerd Font", "monospace";
+}
+
 window#waybar {
 	background: #1a1a1a;
 	color: #fdf6e3;


### PR DESCRIPTION
## What

After a reboot, the waybar battery icon (and pulseaudio volume icons) suddenly rendered noticeably smaller.

## Root cause

Not a waybar change — waybar has been `0.15.0-2` since March. A font-stack update (**pango 1.58.0**, **fontconfig 2.18.2**) changed glyph fallback: the `monospace` family carries a mono spacing hint into fallback selection, so the battery glyphs (`U+F240–F244`, Nerd Font PUA) resolved to `MesloLGS Nerd Font **Mono**` — whose icons are shrunk to a single character cell — instead of a natural-width variant.

## Fix

Pin the non-Mono `MesloLGS Nerd Font` for `#battery` and `#pulseaudio`, so icons render at their natural width. Numeric text still falls through to `monospace`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)