### PR TITLE
Make pocock-implement agent-invocable

### DIFF
--- a/agent-skills/pocock-implement/SKILL.md
+++ b/agent-skills/pocock-implement/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pocock-implement
-description: "Implement a piece of work based on a spec or set of tickets."
-disable-model-invocation: true
+description: Implement a piece of work based on a spec or set of tickets — TDD at agreed seams, typecheck and test as you go, review, then commit. Use when the user wants to build out an agreed spec or work through a set of tickets.
 ---
 
 Implement the work described by the user in the spec or tickets.


### PR DESCRIPTION
`pocock-implement` had `disable-model-invocation: true`, which hid it from the model/agent — only a user could reach it via `/pocock-implement`. That made it effectively not agent-implementable.

## Changes
- Remove `disable-model-invocation: true` so agents can invoke the skill.
- Rewrite the description with a "Use when…" trigger, matching the other model-invocable pocock skills so an agent knows when to reach for it.

Cross-skill reference prefixing was already handled in #170.

🤖 Generated with [Claude Code](https://claude.com/claude-code)