### PR TITLE
Fix Claude settings ask rules

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -107,7 +107,6 @@
     ],
     "ask": [
       "Edit(.claude/settings.json)",
-      "Write(.claude/settings.json)",
       "Bash(gh pr merge*)",
       "Bash(gh repo delete*)"
     ],

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -107,6 +107,8 @@
     ],
     "ask": [
       "Edit(.claude/settings.json)",
+      "Edit(~/.claude/settings.json)",
+      "Edit(~/Projects/dotfiles/claude/settings.json)",
       "Bash(gh pr merge*)",
       "Bash(gh repo delete*)"
     ],


### PR DESCRIPTION
## Summary

Two fixes to the `ask` permission rules in `claude/settings.json`.

**Remove the dead `Write(.claude/settings.json)` rule.** Per the [permissions docs](https://code.claude.com/docs/en/permissions), `Edit` rules already apply to all built-in file-editing tools, and as of Claude Code v2.1.210 a `Write(path)` rule "is accepted but never matched by those checks" — it just produces a startup warning. Nothing is lost by dropping it; the existing `Edit` rule already covered the Write tool.

**Add home-anchored rules for the global settings file.** `Edit(.claude/settings.json)` uses the cwd-relative pattern form, so it anchors at wherever the session started and only matches that project's own `.claude/settings.json`. It never reaches `~/.claude/settings.json` — the docs are explicit that a rule doesn't match files in a parent directory.

That left the file this repo actually manages unguarded, under both of its names:

- `~/.claude/settings.json` (the symlink)
- `~/Projects/dotfiles/claude/settings.json` (the target in this repo)

Both are now listed. The docs describe symlink double-checking for allow and deny rules but say nothing about `ask`, so both spellings are covered explicitly rather than relying on resolution. The original `Edit(.claude/settings.json)` line stays — it still does a useful and separate job guarding per-project settings files.

## Test plan

- [x] `python3 -m json.tool claude/settings.json` passes
- [ ] Confirm no `is not matched by file permission checks` warning at next Claude Code startup
- [ ] Confirm an edit to `~/.claude/settings.json` now prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)