### PR TITLE
Add status line showing context token usage

### DIFF
--- a/claude/bin/statusline.sh
+++ b/claude/bin/statusline.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Claude Code status line: directory, model, context/token usage, session cost.
+# Receives session JSON on stdin. See https://code.claude.com/docs/en/statusline
+
+input=$(cat)
+
+field() { echo "$input" | jq -r "$1"; }
+
+dir=$(basename "$(field '.workspace.current_dir')")
+model=$(field '.model.display_name')
+used=$(field '.context_window.used_percentage // 0')
+tin=$(field '.context_window.total_input_tokens // 0')
+tout=$(field '.context_window.total_output_tokens // 0')
+size=$(field '.context_window.context_window_size // 0')
+cost=$(field '.cost.total_cost_usd // empty')
+
+# 41990 -> 42k, 1000000 -> 1m, 1240000 -> 1.2m, 320 -> 320
+human() {
+  awk -v n="$1" 'BEGIN {
+    n += 0
+    if (n >= 1000000) { s = sprintf("%.1f", n / 1000000); sub(/\.0$/, "", s); print s "m" }
+    else if (n >= 1000) { printf "%.0fk\n", n / 1000 }
+    else { printf "%d\n", n }
+  }'
+}
+
+# Green under 50% of the context window, yellow to 80%, red beyond.
+color=$(awk -v u="$used" 'BEGIN {
+  u += 0
+  if (u >= 80) print "31"; else if (u >= 50) print "33"; else print "32"
+}')
+pct=$(awk -v u="$used" 'BEGIN { printf "%.0f", u + 0 }')
+
+printf '\033[2m%s\033[0m \033[36m%s\033[0m \033[1;%sm[ctx %s%% | %s/%s tok]\033[0m' \
+  "$dir" "$model" "$color" "$pct" "$(human $((tin + tout)))" "$(human "$size")"
+
+if [ -n "$cost" ]; then
+  printf ' \033[2m$%.2f\033[0m' "$cost"
+fi

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -122,6 +122,10 @@
   "promptSuggestionEnabled": false,
   "skipAutoPermissionPrompt": true,
   "skipDangerousModePermissionPrompt": true,
+  "statusLine": {
+    "command": "$HOME/.claude/bin/statusline.sh",
+    "type": "command"
+  },
   "teammateMode": "tmux",
   "theme": "auto"
 }


### PR DESCRIPTION
Adds a Claude Code status line so context/token consumption is visible at all times, instead of only via `/context`.

```
dotfiles  Opus 5  [ctx 34% | 68k/200k tok]  $0.42
```

## What's here

- **`claude/bin/statusline.sh`** — reads the session JSON on stdin and prints directory, model, context usage, and session cost. Styled to echo the dimmed/colored segments of the zsh prompt in `zsh/prompt.zsh`.
- **`claude/settings.json`** — points `statusLine.command` at `$HOME/.claude/bin/statusline.sh`, matching the convention the existing `claude-notify-sfx.py` hooks use.

No `setup.sh` change needed — `claude/bin` is already symlinked to `~/.claude/bin`.

## Details

- Token counts are human-readable: `42k/1m` rather than `41990/1000000`. Values under 1000 print raw, so a fresh session shows `320/200k` instead of a misleading `0k`.
- Context block is color-coded: green under 50%, yellow to 80%, red beyond.
- Uses the documented `context_window.*` fields, so no transcript parsing.

## Testing

Ran the configured command against sample payloads covering normal usage, a 1m-token context window, the >80% red threshold, and the two documented degenerate cases — cold start and post-`/compact`, where `used_percentage` is `null` and token totals are `0`. All render correctly; the `// 0` guards cover the nulls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)