### PR TITLE
Remove DISABLE_TELEMETRY from Claude settings

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -14,8 +14,7 @@
     "typescript-lsp@claude-plugins-official": true
   },
   "env": {
-    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
-    "DISABLE_TELEMETRY": "1"
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
   "hooks": {
     "Notification": [


### PR DESCRIPTION
Drops the `DISABLE_TELEMETRY=1` env var from `claude/settings.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)