### PR TITLE
Add meat skill for abridging diffs into reading diffs

### DIFF
--- a/agent-skills/meat/INSTALL.md
+++ b/agent-skills/meat/INSTALL.md
@@ -1,0 +1,92 @@
+# Installing meatx
+
+The `meat` skill drives `meatx`, a small CLI over a personal fork of
+[boldsoftware/meat](https://github.com/boldsoftware/meat). Upstream `meat` calls
+an LLM API itself; `meatx` splits that apart so the agent already in the session
+supplies the judgment, and no API key or provider call is involved.
+
+- Fork: <https://github.com/thavelick/meat>
+- Working copy: `~/Projects/meat`, on `main`
+- Binary: `~/go/bin/meatx` (already on `$PATH` via `zsh/core.zsh`)
+
+The fork follows upstream's own habit: one branch, linear history, no merge
+commits. Our commits sit directly on top of theirs.
+
+## Requirements
+
+- **Go** — 1.26+. `brew install go` / `pacman -S go`.
+- **git-delta** — optional, for reading the result in color. Already configured
+  in `git/gitconfig`.
+- **gh** — only for abridging PRs by number.
+
+Upstream has no third-party dependencies, so there is nothing to `go mod
+download`.
+
+## First install
+
+```sh
+git clone git@github.com:thavelick/meat.git ~/Projects/meat
+cd ~/Projects/meat
+git remote add upstream https://github.com/boldsoftware/meat.git
+go build -o ~/go/bin/meatx ./cmd/meatx
+```
+
+Verify:
+
+```sh
+meatx                       # prints usage
+go test ./...               # upstream suite + the filter tests
+```
+
+## Rebuild after changing the fork
+
+```sh
+cd ~/Projects/meat && go build -o ~/go/bin/meatx ./cmd/meatx
+```
+
+## Updating from upstream
+
+Our two commits sit on top of upstream's `main`, so an update is a rebase that
+replays them onto whatever they have added:
+
+```sh
+cd ~/Projects/meat
+git fetch upstream
+git rebase upstream/main
+go test ./... && go build -o ~/go/bin/meatx ./cmd/meatx
+git push --force-with-lease origin main
+```
+
+The force-push is expected — rebasing rewrites our two commits onto new parents.
+`--force-with-lease` refuses if the fork moved underneath you.
+
+**Expect this to break occasionally, and expect it to break loudly.**
+`meat/agentshim.go` is a re-export of unexported internals — `numberedDiff`,
+`buildUserPrompt`, `compileSubmission`, `editPlanToolSchema`, `fitsSingleRun`.
+An upstream rename fails the build rather than silently changing behavior, so a
+red `go build` after a rebase means "a name moved", not "the abridging is
+wrong". Fix by finding the new name in `meat/`.
+
+## What the fork adds
+
+Two commits on top of upstream's tip, each building and passing tests on its
+own (so a bisect never lands on a broken state):
+
+- `meat/agentshim.go` — `Prepare` stops just before the model call and returns
+  the assembled prompt; `ApplyPlan` compiles an externally-authored edit plan
+  with the same validation `submit` performs. Re-exports only, no behavior
+  change.
+- `cmd/meatx` — `prep` and `apply`, plus the generated-file filter that drops
+  lockfiles, vendored output, snapshots and compiled artifacts before numbering,
+  naming on stderr whatever it dropped.
+
+## Known limits
+
+- **Chunking is not wired up.** Diffs over ~400KB numbered (roughly 8,000
+  changed lines of ordinary source) would be split by upstream `Abridge`;
+  `meatx prep` only warns. Rarely reachable once generated files are excluded.
+- **The output is not an applicable patch.** Hunk counts go stale wherever rows
+  were dropped, so delta's line numbers drift within a cut hunk. Never
+  `git apply` it.
+- **Files are never reordered**, only dropped — so a move between files still
+  shows its two sides far apart, wherever git put them.

--- a/agent-skills/meat/SKILL.md
+++ b/agent-skills/meat/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: meat
+description: Abridge a diff into a "reading diff" — drop mechanical noise, keep what carries meaning. Use when the user wants to read/review a large diff, PR, or commit at the concept level rather than line by line.
+disable-model-invocation: false
+argument-hint: "[pr-number | revision | range | -w | -staged]"
+---
+
+Abridge `$ARGUMENTS` into a reading diff.
+
+You are the model in meat's agent loop. `meatx` does the deterministic halves —
+prompt assembly and plan compilation — and you supply the judgment in between.
+You never write the output diff: you write an **edit plan** of coordinates, and
+`meatx apply` applies it to the original. That is the whole point, so do not
+hand-write diff text at any stage.
+
+A bare integer argument is a PR number. Anything else is passed to git as a
+revision, a range, or one of `-w` / `-staged`.
+
+If `meatx` is not on `$PATH`, stop and follow [INSTALL.md](INSTALL.md) — it also
+covers rebuilding after a fork change and rebasing onto upstream.
+
+## 1. Prepare
+
+Pick a scratch path and keep it for the whole run, so concurrent sessions don't
+clobber each other:
+
+```sh
+STATE=$(mktemp -d)/orig.diff
+```
+
+Then get the numbered diff. `prep` reads stdin, a revision, a range, `-w`, or
+`-staged`; run it from inside the target repo so the paths resolve:
+
+```sh
+# a PR
+gh pr diff <N> | MEATX_STATE=$STATE meatx prep > /tmp/prompt.txt
+# a commit, a range, the working tree
+MEATX_STATE=$STATE meatx prep <rev|range|-w|-staged> > /tmp/prompt.txt
+```
+
+`prep` drops generated files before numbering — lockfiles, vendored and build
+output, snapshots, compiled protobufs and the like, across every ecosystem — and
+names on stderr exactly what it excluded. This is a context saving, not a
+judgment: a lockfile is routinely 90%+ of a scaffolding diff's bytes and none of
+it is readable. Pass on what it dropped when you report.
+
+The default set can't know your repo's conventions. Add to it, or opt out:
+
+```sh
+# also drop this project's generated or uninteresting paths
+... | MEATX_STATE=$STATE meatx prep -x 'db/migrations/*' -x '*.pot'
+# abridge everything, generated files included
+... | MEATX_STATE=$STATE meatx prep -no-default-excludes
+```
+
+Exclude patterns: `*.lock` matches a basename, `a/b/*.py` matches a full path,
+`dir/` matches that directory at any depth, `/dir/` only at the repo root.
+
+Read `/tmp/prompt.txt`. It contains meat's own instructions plus the diff with a
+1-based `N|` gutter. If it warns the diff exceeds one agent run, say so — the
+plan will still compile, but meat proper would have chunked it. That threshold
+is ~8,000 changed lines of ordinary source, so with generated files excluded it
+is rarely reachable.
+
+## 2. Plan
+
+Write a JSON plan. Three op arrays, **all three required even when empty**:
+
+```json
+{
+  "summary": "One line: what the change does, at the concept level.",
+  "remove":  [{ "start_line": 17, "end_line": 25 }],
+  "replace": [{ "line": 42, "old": "...", "new": "..." }],
+  "fold":    [{ "start_line": 36, "end_line": 54 }]
+}
+```
+
+Rules the compiler enforces — violating these is a hard reject, not a warning:
+
+- Coordinates are the `N|` gutter numbers on the **original**, 1-based and
+  inclusive. They never shift as you remove things. The gutter itself is not
+  part of the line's text.
+- `fold` needs **two or more contiguous lines of the same polarity** (all `+`,
+  or all `-`, or all context). It collapses them to one indentation-preserving
+  `...` row. Crossing a polarity boundary is rejected.
+- `replace` elides *part of one line*. `new` must contain everything in `old`
+  except spans visibly replaced by `...` or `…`. Use it rarely.
+- Imports are stripped mechanically before you ever see the result. Never spend
+  coordinates on them, never fold across them, never mention them in the summary.
+- If move hints appear in the prompt, both sides of each pair need identical
+  treatment. Asymmetric plans are rejected.
+
+What to cut, in rough priority order:
+
+- **A mechanical change repeated across N files.** Keep one representative file
+  in full; `remove` the rest outright. This is usually the single biggest win.
+- **Test bodies.** Keep the `it(`/`test(`/`def test_` names — they are the
+  contract, and reading them in a list is the fastest way to see what the change
+  claims. Fold the mock setup and assertion blocks under each.
+- **Mechanical function bodies** — env plumbing, URL building, JSON marshalling,
+  error-message construction, field-by-field copies.
+- **Whole hunks that survive only as context** after imports are stripped.
+
+What to keep, always:
+
+- Doc comments and rationale. In this codebase they carry the design argument —
+  the *why* — which is exactly what a reviewer cannot reconstruct from the code.
+- Type and interface declarations, exported signatures.
+- Control flow, conditions, lifecycle edges, retry/backoff decisions, security
+  boundaries, and anything a comment flags as a caveat or hazard.
+
+## 3. Apply
+
+```sh
+MEATX_STATE=$STATE meatx apply /tmp/plan.json > /tmp/reading.diff
+```
+
+Invalid plans are rejected with a reason on stderr — fix and re-run, that loop
+is cheap. On success stderr carries the retention feedback:
+
+```
+Retention: 249/612 visible changed rows (40%); 98 removed, 299 hidden by 34 folds; files 6/9.
+```
+
+**Do at most one refinement pass.** Tighten if retention is above ~45%, or if
+scanning the output shows something obviously mechanical still in full. Then
+stop. The "Pressure: high retention" line fires on any diff with more than 80
+visible rows, so on a large PR it is essentially always present — treat it as
+advisory, never as a gate to loop against.
+
+## 4. Show it
+
+Their delta config is wired through `pager.diff`/`pager.show`, which only apply
+to real git subcommands, so pipe explicitly:
+
+```sh
+delta < /tmp/reading.diff
+```
+
+Then give the user the summary line, the retention numbers, and a short note on
+what you dropped and why — any whole file you removed, plus anything `prep`
+excluded as generated, so nothing disappears silently.
+
+## Notes
+
+- `meatx` is a shim over boldsoftware/meat, forked to
+  [thavelick/meat](https://github.com/thavelick/meat) and worked on in
+  `~/Projects/meat`. It makes **no API call** — you are the model, and the work
+  runs on the session's existing subscription. See [INSTALL.md](INSTALL.md).
+- The reading diff is deliberately **not an applicable patch**: hunk line counts
+  go stale where rows were dropped, so delta's line numbers drift within any
+  hunk you cut. Never feed the output to `git apply`.
+- Chunking for very large diffs lives behind meat's own `Abridge` and is not
+  wired up here.


### PR DESCRIPTION
Adds a `/meat` skill that reduces a diff to the parts worth reading — mechanical
noise elided, behaviour-bearing changes kept — for reviewing at the concept level
rather than line by line.

It wraps [boldsoftware/meat](https://github.com/boldsoftware/meat), which does
this well but calls an LLM API itself, needing a key and billing per token.
[thavelick/meat](https://github.com/thavelick/meat) splits meat's two
deterministic halves — prompt assembly and plan compilation — away from the model
call, so the agent already in the session supplies the judgment. No API key, no
provider request, and it reuses the repo context the session already holds.

The agent never writes the output diff. It submits an edit plan of coordinates
against the numbered original; meat's compiler applies it and rejects bad
coordinates, asymmetric treatment of moved code, and folds that cross a polarity
boundary. What gets displayed is always real source text.

## Files

- `SKILL.md` — the workflow: prep, plan, apply, show. Includes what to cut
  (repeated call-site edits, test bodies, mechanical plumbing) and what to always
  keep (rationale comments, signatures, control flow, security boundaries).
- `INSTALL.md` — building the fork, rebuilding after a change, rebasing onto
  upstream, and the known limits.

## Tried on real PRs

On a 779-line TaxBandits transport PR: **304 lines out, 40% of changed rows
retained, 3 of 9 files dropped entirely.** Three of four probe scripts went
(identical mechanical edit — one kept as the anchor), every test body folded to
its `it()` name, and the whole design rationale survived.

Verified along the way:

- All three of meat's own golden fixtures reproduce byte-for-byte through the
  compiler.
- Move symmetry genuinely enforced — a plan touching one side of a real move pair
  is rejected naming both ranges.
- `INSTALL.md` followed verbatim from a clean clone on a scratch machine path.

## Notes

- `prep` drops generated files before numbering and always names what it dropped.
  On the repo-scaffolding PR that was 94% of the prompt (a `pnpm-lock.yaml`).
- The output is deliberately **not an applicable patch** — hunk counts go stale
  where rows were cut. Never `git apply` it.
- Chunking for very large diffs is not wired up; the threshold is roughly 8,000
  changed lines of ordinary source, rarely reachable once generated files are out.