### PR TITLE
Read meat's output as HTML instead of piping it to delta

### DIFF
--- a/agent-skills/meat/INSTALL.md
+++ b/agent-skills/meat/INSTALL.md
@@ -15,9 +15,12 @@ commits. Our commits sit directly on top of theirs.
 ## Requirements
 
 - **Go** — 1.26+. `brew install go` / `pacman -S go`.
-- **git-delta** — optional, for reading the result in color. Already configured
-  in `git/gitconfig`.
+- **bun** — for `bunx`, which `meat-view` uses to render the page. No global
+  install of `diff2html-cli` is needed; `bunx` fetches the pinned version on
+  first use and caches it.
 - **gh** — only for abridging PRs by number.
+
+`meat-view` and `qopen` both ship in this repo's `bin/`, already on `$PATH`.
 
 Upstream has no third-party dependencies, so there is nothing to `go mod
 download`.
@@ -86,7 +89,7 @@ own (so a bisect never lands on a broken state):
   changed lines of ordinary source) would be split by upstream `Abridge`;
   `meatx prep` only warns. Rarely reachable once generated files are excluded.
 - **The output is not an applicable patch.** Hunk counts go stale wherever rows
-  were dropped, so delta's line numbers drift within a cut hunk. Never
-  `git apply` it.
+  were dropped, so line numbers drift within a cut hunk — which is why
+  `meat-view` hides them. Never `git apply` it.
 - **Files are never reordered**, only dropped — so a move between files still
   shows its two sides far apart, wherever git put them.

--- a/agent-skills/meat/SKILL.md
+++ b/agent-skills/meat/SKILL.md
@@ -33,16 +33,18 @@ Then get the numbered diff. `prep` reads stdin, a revision, a range, `-w`, or
 
 ```sh
 # a PR
-gh pr diff <N> | MEATX_STATE=$STATE meatx prep > /tmp/prompt.txt
+gh pr diff <N> | MEATX_STATE=$STATE meatx prep > /tmp/prompt.txt 2>/tmp/excluded.txt
 # a commit, a range, the working tree
-MEATX_STATE=$STATE meatx prep <rev|range|-w|-staged> > /tmp/prompt.txt
+MEATX_STATE=$STATE meatx prep <rev|range|-w|-staged> > /tmp/prompt.txt 2>/tmp/excluded.txt
 ```
 
 `prep` drops generated files before numbering — lockfiles, vendored and build
 output, snapshots, compiled protobufs and the like, across every ecosystem — and
 names on stderr exactly what it excluded. This is a context saving, not a
 judgment: a lockfile is routinely 90%+ of a scaffolding diff's bytes and none of
-it is readable. Pass on what it dropped when you report.
+it is readable. Keep that stderr in `/tmp/excluded.txt` — step 4 puts it in the
+page, so the reader can see what vanished before the abridging even started.
+Read it yourself too, so nothing surprises you when you report.
 
 The default set can't know your repo's conventions. Add to it, or opt out:
 
@@ -130,16 +132,39 @@ advisory, never as a gate to loop against.
 
 ## 4. Show it
 
-Their delta config is wired through `pager.diff`/`pager.show`, which only apply
-to real git subcommands, so pipe explicitly:
+`meat-view` renders the reading diff as a side-by-side HTML page and opens it in
+the browser, to be read in a tab beside the PR itself. Run it from inside the
+target repo — the page lands in that repo's git-ignored `scratch/meat-diffs/`:
 
 ```sh
-delta < /tmp/reading.diff
+meat-view /tmp/reading.diff \
+  --orig "$STATE" \
+  --excluded /tmp/excluded.txt \
+  --target pr-175 \
+  --title "PR #175 — drop the v1 compatibility layer" \
+  --note "The four deleted tests keep their names; fixtures and assertions are
+folded. Eight call sites got the same mechanical rename — kept client.ts as the
+representative and dropped the rest."
 ```
 
-Then give the user the summary line, the retention numbers, and a short note on
-what you dropped and why — any whole file you removed, plus anything `prep`
-excluded as generated, so nothing disappears silently.
+`--target` names the file, so use what was abridged: `pr-<N>`, the short sha, a
+sanitized rev, `worktree`, or `staged`. Never leave it off — the default is a
+characterless `reading.html`. Repeat runs are numbered rather than overwritten,
+so prior renders survive.
+
+The page carries its own provenance, which is why the flags matter. `--orig`
+lets it derive which files were dropped whole, by comparing `$STATE`'s file list
+against the reading diff's. `--excluded` surfaces what `prep` skipped as
+generated. `--note` is the one thing no script can derive — *why* what went
+missing was safe to lose, in your words. Write it as prose, and name the
+representative file whenever you kept one and dropped its siblings.
+
+Line numbers are hidden in the page: folds make them drift within a hunk, so
+they would be quietly wrong. The `@@` headers stay, and are accurate.
+
+Then keep the terminal short — the page is the artifact, not the transcript.
+Three lines: the path it printed, the retention numbers, and the one-line
+summary. The full account of what you dropped belongs in `--note`, not here.
 
 ## Notes
 
@@ -148,7 +173,12 @@ excluded as generated, so nothing disappears silently.
   `~/Projects/meat`. It makes **no API call** — you are the model, and the work
   runs on the session's existing subscription. See [INSTALL.md](INSTALL.md).
 - The reading diff is deliberately **not an applicable patch**: hunk line counts
-  go stale where rows were dropped, so delta's line numbers drift within any
-  hunk you cut. Never feed the output to `git apply`.
+  go stale where rows were dropped, so line numbers drift within any hunk you
+  cut. Never feed the output to `git apply`.
+- `meat-view` lives in `bin/meat-view` in the dotfiles repo, with its page
+  template beside it. It shells out to `bunx diff2html-cli@5.2.15` — pinned, so
+  an upstream change breaks loudly instead of quietly restyling the page — and
+  opens the result with `qopen`. Nothing to install: `bunx` fetches on first
+  use and caches.
 - Chunking for very large diffs lives behind meat's own `Abridge` and is not
   wired up here.

--- a/bin/meat-view
+++ b/bin/meat-view
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Render a meat reading diff to a standalone HTML page and open it."""
+
+import argparse
+import html
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+HELP = """Usage: meat-view <reading.diff> [OPTIONS]
+
+Render a meat "reading diff" as a side-by-side HTML page and open it in the
+browser. The page carries a header band explaining what the abridgement left
+out, so the artifact accounts for its own omissions.
+
+Options:
+  --orig <file>       The original (unabridged) diff, i.e. meat's $STATE.
+                      Used to derive which files were dropped whole.
+  --excluded <file>   File holding `meatx prep` stderr, i.e. the generated
+                      files it excluded before numbering.
+  --note <text>       Prose about what was dropped and why.
+  --target <name>     Names the output file: pr-175, worktree, staged, a sha.
+                      Defaults to "reading".
+  --title <text>      Page title / header line. Defaults to the target.
+  -h, --help          Show this help.
+
+Output goes to <repo>/scratch/meat-diffs/<target>.html, or $TMPDIR if that
+path is not git-ignored. Repeat runs are numbered (pr-175-2.html); prior
+renders are never overwritten.
+
+Requirements:
+  - bunx (renders via diff2html-cli)
+  - qopen
+  - git
+"""
+
+DIFF2HTML = "diff2html-cli@5.2.15"
+TEMPLATE = os.path.join(os.path.dirname(os.path.abspath(__file__)), "meat-view-template.html")
+
+
+def die(msg):
+    print(f"Error: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def read(path):
+    try:
+        with open(path, encoding="utf-8", errors="replace") as f:
+            return f.read()
+    except OSError as e:
+        die(f"cannot read {path}: {e}")
+
+
+def parse_header_lines(text):
+    """Pull the leading `#` comment lines off a reading diff.
+
+    Returns (summary, retention). The `kept N/M ...` line is the last one.
+    """
+    lines = []
+    for line in text.splitlines():
+        if line.startswith("#"):
+            lines.append(line.lstrip("#").strip())
+        elif line.strip() == "" and lines:
+            continue
+        else:
+            break
+    retention = ""
+    if lines and lines[-1].startswith("kept "):
+        retention = lines.pop()
+    return " ".join(lines).strip(), retention
+
+
+def diff_files(text):
+    """File paths named by `diff --git a/X b/Y` lines, in order."""
+    seen = []
+    for m in re.finditer(r"^diff --git a/(\S+) b/(\S+)", text, re.M):
+        path = m.group(2)
+        if path not in seen:
+            seen.append(path)
+    return seen
+
+
+def rich(text):
+    """HTML-escape, then render `backticked` spans as <code>."""
+    return re.sub(r"`([^`]+)`", r"<code>\1</code>", html.escape(text))
+
+
+def details(summary, body_html, open_=False):
+    attr = " open" if open_ else ""
+    return (
+        f'<details class="meat-details"{attr}><summary>{html.escape(summary)}'
+        f"</summary>{body_html}</details>"
+    )
+
+
+def bullet_list(items):
+    return "<ul>" + "".join(f"<li>{html.escape(i)}</li>" for i in items) + "</ul>"
+
+
+def build_band(summary, retention, dropped, excluded, note):
+    parts = []
+    if summary:
+        parts.append(f'<p class="meat-summary">{rich(summary)}</p>')
+
+    chips = []
+    if retention:
+        chips.append(f'<span class="meat-chip">{html.escape(retention)}</span>')
+    if dropped:
+        n = len(dropped)
+        chips.append(
+            f'<span class="meat-chip">{n} file{"s" if n != 1 else ""} dropped whole</span>'
+        )
+    chips.append(
+        '<span class="meat-chip meat-chip-warn">line numbers hidden &mdash; folds '
+        "make them drift; not an applicable patch</span>"
+    )
+    parts.append('<div class="meat-facts">' + "".join(chips) + "</div>")
+
+    if note:
+        parts.append(f'<p class="meat-note">{rich(note)}</p>')
+
+    if dropped:
+        parts.append(
+            details(
+                f"Dropped whole ({len(dropped)})",
+                bullet_list(dropped),
+                open_=len(dropped) <= 5,
+            )
+        )
+    if excluded:
+        parts.append(
+            details(
+                "Excluded as generated before abridging",
+                f"<pre>{html.escape(excluded.strip())}</pre>",
+            )
+        )
+    return "\n".join(parts)
+
+
+def output_dir():
+    """<repo>/scratch/meat-diffs if git-ignored, else $TMPDIR."""
+    try:
+        top = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        top = ""
+    if top:
+        target = os.path.join(top, "scratch", "meat-diffs")
+        os.makedirs(target, exist_ok=True)
+        ignored = subprocess.run(
+            ["git", "check-ignore", "-q", target], cwd=top
+        ).returncode == 0
+        if ignored:
+            return target
+        print(
+            f"Notice: {target} is not git-ignored; writing to $TMPDIR instead.",
+            file=sys.stderr,
+        )
+    return tempfile.gettempdir()
+
+
+def next_free(directory, stem):
+    candidate = os.path.join(directory, f"{stem}.html")
+    n = 1
+    while os.path.exists(candidate):
+        n += 1
+        candidate = os.path.join(directory, f"{stem}-{n}.html")
+    return candidate
+
+
+def main():
+    if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help"):
+        print(HELP)
+        sys.exit(0)
+
+    p = argparse.ArgumentParser(add_help=False)
+    p.add_argument("reading")
+    p.add_argument("--orig")
+    p.add_argument("--excluded")
+    p.add_argument("--note")
+    p.add_argument("--target")
+    p.add_argument("--title")
+    args = p.parse_args()
+
+    for cmd in ("bunx", "qopen", "git"):
+        if not shutil.which(cmd):
+            die(f"{cmd} is required but not installed")
+
+    reading = read(args.reading)
+    summary, retention = parse_header_lines(reading)
+
+    dropped = []
+    if args.orig:
+        kept = set(diff_files(reading))
+        dropped = [f for f in diff_files(read(args.orig)) if f not in kept]
+
+    # prep writes nothing to stderr when it excluded nothing, and a file
+    # holding only whitespace must not become an empty disclosure block.
+    excluded = read(args.excluded).strip() if args.excluded else ""
+
+    target = args.target or "reading"
+    stem = re.sub(r"[^A-Za-z0-9._-]", "-", target.replace("/", "-")).strip("-") or "reading"
+    title = args.title or target
+
+    band = build_band(summary, retention, dropped, excluded, args.note)
+
+    tmpl = read(TEMPLATE)
+    if "<!--meat-header-->" not in tmpl:
+        die(f"{TEMPLATE} is missing the <!--meat-header--> placeholder")
+
+    out = next_free(output_dir(), stem)
+
+    with tempfile.NamedTemporaryFile(
+        "w", suffix=".html", delete=False, encoding="utf-8"
+    ) as tf:
+        tf.write(tmpl.replace("<!--meat-header-->", band))
+        tmpl_path = tf.name
+
+    try:
+        subprocess.run(
+            [
+                "bunx", DIFF2HTML,
+                "-s", "side",
+                "-i", "file",
+                "--cs", "auto",
+                "--su", "open",
+                "--hwt", tmpl_path,
+                "-t", title,
+                "-F", out,
+                "--", args.reading,
+            ],
+            check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        die(f"diff2html failed (exit {e.returncode})")
+    finally:
+        os.unlink(tmpl_path)
+
+    print(out)
+    subprocess.run(["qopen", out])
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/meat-view-template.html
+++ b/bin/meat-view-template.html
@@ -1,0 +1,222 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title><!--diff2html-title--></title>
+
+    <!--
+      Diff to HTML wrapper, customized for meat-view (bin/meat-view).
+      Based on diff2html-cli's stock template.html by rtfpessoa.
+      The diff2html-title / diff2html-css / diff2html-js-ui / diff2html-header /
+      diff2html-diff comment placeholders and the //diff2html-* script lines are
+      substituted by diff2html-cli; do not remove them. The meat-header comment
+      placeholder is substituted by meat-view itself.
+    -->
+
+    <!--diff2html-css-->
+
+    <!--diff2html-js-ui-->
+
+    <style>
+      :root {
+        --meat-bg: #ffffff;
+        --meat-fg: #1f2328;
+        --meat-muted: #59636e;
+        --meat-border: #d1d9e0;
+        --meat-subtle: #f6f8fa;
+        --meat-accent: #8250df;
+        --meat-warn: #9a6700;
+        --meat-warn-bg: #fff8c5;
+      }
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --meat-bg: #0d1117;
+          --meat-fg: #e6edf3;
+          --meat-muted: #9198a1;
+          --meat-border: #3d444d;
+          --meat-subtle: #151b23;
+          --meat-accent: #d2a8ff;
+          --meat-warn: #d29922;
+          --meat-warn-bg: #272115;
+        }
+      }
+
+      body {
+        margin: 0;
+        background: var(--meat-bg);
+        color: var(--meat-fg);
+      }
+
+      /* The stock template centers everything; the diff must not be centered. */
+      #diff {
+        text-align: left;
+      }
+
+      /* ---- header band ------------------------------------------------- */
+
+      .meat-band {
+        text-align: left;
+        padding: 18px 20px 14px;
+        border-bottom: 1px solid var(--meat-border);
+        background: var(--meat-subtle);
+        font-size: 14px;
+        line-height: 1.5;
+      }
+      .meat-band-inner {
+        max-width: 105ch;
+      }
+      .meat-eyebrow {
+        display: flex;
+        align-items: baseline;
+        gap: 10px;
+        flex-wrap: wrap;
+        margin-bottom: 8px;
+      }
+      .meat-tag {
+        font-size: 10px;
+        font-weight: 700;
+        letter-spacing: 0.09em;
+        text-transform: uppercase;
+        color: var(--meat-accent);
+        border: 1px solid currentColor;
+        border-radius: 999px;
+        padding: 2px 8px;
+        white-space: nowrap;
+      }
+      .meat-band h1 {
+        font-size: 15px;
+        font-weight: 600;
+        margin: 0;
+        color: var(--meat-muted);
+      }
+      .meat-summary {
+        margin: 0 0 10px;
+        font-size: 17px;
+        line-height: 1.45;
+      }
+      .meat-summary code,
+      .meat-note code {
+        font-size: 0.88em;
+        background: var(--meat-bg);
+        border: 1px solid var(--meat-border);
+        border-radius: 4px;
+        padding: 0 4px;
+      }
+      .meat-facts {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+        margin-bottom: 4px;
+      }
+      .meat-chip {
+        font-size: 12px;
+        color: var(--meat-muted);
+        background: var(--meat-bg);
+        border: 1px solid var(--meat-border);
+        border-radius: 999px;
+        padding: 2px 10px;
+      }
+      .meat-chip-warn {
+        color: var(--meat-warn);
+        background: var(--meat-warn-bg);
+        border-color: var(--meat-warn);
+      }
+      .meat-note {
+        margin: 10px 0 0;
+        padding-left: 10px;
+        border-left: 3px solid var(--meat-border);
+        color: var(--meat-fg);
+      }
+      .meat-details {
+        margin-top: 8px;
+      }
+      .meat-details > summary {
+        cursor: pointer;
+        font-size: 13px;
+        color: var(--meat-muted);
+        list-style-position: outside;
+      }
+      .meat-details > summary:hover {
+        color: var(--meat-fg);
+      }
+      .meat-details ul {
+        margin: 6px 0 0;
+        padding-left: 26px;
+        font-size: 13px;
+        color: var(--meat-muted);
+      }
+      .meat-details li {
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 12px;
+      }
+      .meat-details pre {
+        margin: 6px 0 0 16px;
+        font-size: 12px;
+        white-space: pre-wrap;
+        color: var(--meat-muted);
+      }
+
+      /* ---- sticky file list -------------------------------------------- */
+
+      .d2h-file-list-wrapper {
+        position: sticky;
+        top: 0;
+        z-index: 10;
+        background: #fff;
+        max-height: 40vh;
+        overflow: auto;
+        box-shadow: 0 2px 6px rgba(0, 0, 0, 0.15);
+        text-align: left;
+        margin-bottom: 0;
+        padding: 10px 20px;
+      }
+      @media (prefers-color-scheme: dark) {
+        .d2h-file-list-wrapper {
+          background: #0d1117;
+          box-shadow: 0 2px 6px rgba(0, 0, 0, 0.6);
+        }
+      }
+      .d2h-wrapper {
+        padding: 16px 20px 60px;
+      }
+
+      /* ---- hidden line numbers ------------------------------------------
+         meat's folds make in-hunk line numbers wrong, so they are not shown.
+         The gutter itself stays: it is what separates the two sides. */
+      /* !important because diff2html's dark rules are
+         `.d2h-auto-color-scheme .d2h-code-side-linenumber`, which outranks a
+         bare class selector — without it the numbers reappear in dark mode. */
+      .d2h-code-side-linenumber,
+      .d2h-code-linenumber {
+        color: transparent !important;
+      }
+    </style>
+
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        const targetElement = document.getElementById('diff');
+        const diff2htmlUi = new Diff2HtmlUI(targetElement);
+        //diff2html-fileListToggle
+        //diff2html-fileContentToggle
+        //diff2html-synchronisedScroll
+        //diff2html-highlightCode
+      });
+    </script>
+  </head>
+  <body style="text-align: center; font-family: 'Source Sans Pro', sans-serif">
+    <header class="meat-band">
+      <div class="meat-band-inner">
+        <div class="meat-eyebrow">
+          <span class="meat-tag">reading diff</span>
+          <h1><!--diff2html-header--></h1>
+        </div>
+        <!--meat-header-->
+      </div>
+    </header>
+
+    <div id="diff">
+      <!--diff2html-diff-->
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
The `meat` skill's last step piped the reading diff to `delta`. That's the wrong shape for how these get read: the terminal competes for the same window as the PR, truncates on anything large (the last real run opened with an apology for exactly that), and leaves nothing behind once the scrollback is gone.

`bin/meat-view` renders the reading diff side-by-side in the browser instead, to be read in a tab beside GitHub's own view of the same PR.

## The header band

The page explains its own omissions, because a reading diff otherwise quietly misreports what changed — its per-file `+N −N` counts describe the *abridged* diff, and whole files can vanish without a trace. The band carries:

- **summary + retention**, parsed from the `#` lines `meatx apply` already writes into the diff (diff2html drops them, so they're re-injected)
- **files dropped whole**, derived by comparing `$STATE`'s file list against the reading diff's
- **generated exclusions**, from `meatx prep`'s stderr
- **`--note`**, the only agent-authored string: why what went missing was safe to lose

## Line numbers

Hidden, not shown. meat's folds make them drift within a hunk — measured against a real PR, a row displayed as `113` was actually line `142`. A wrong number is worse than no number. The gutter column stays, since it's what separates the two panes, and the `@@` headers are untouched and accurate.

## Notes

- `bunx diff2html-cli@5.2.15`, pinned. The sticky file list styles diff2html's own class names, so an upstream restyle should break loudly rather than quietly rearrange the page. Nothing to install — `bunx` fetches and caches.
- Output goes to the target repo's git-ignored `scratch/meat-diffs/`, named for what was abridged (`pr-232.html`), numbered on re-runs so prior renders survive. If `scratch/` turns out not to be ignored, it falls back to `$TMPDIR` and says so.
- Opens with `qopen`, so this works on the Linux boxes too.

Verified end to end against a real prior run (1099-filer PR #232) using the exact invocation the skill now documents. shellcheck and ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)