### PR TITLE
Link the meat page to its source and keep file bars on screen

### DIFF
--- a/agent-skills/meat/SKILL.md
+++ b/agent-skills/meat/SKILL.md
@@ -140,6 +140,7 @@ target repo — the page lands in that repo's git-ignored `scratch/meat-diffs/`:
 meat-view /tmp/reading.diff \
   --orig "$STATE" \
   --excluded /tmp/excluded.txt \
+  --pr 175 \
   --target pr-175 \
   --title "PR #175 — drop the v1 compatibility layer" \
   --note "The four deleted tests keep their names; fixtures and assertions are
@@ -151,6 +152,13 @@ representative and dropped the rest."
 sanitized rev, `worktree`, or `staged`. Never leave it off — the default is a
 characterless `reading.html`. Repeat runs are numbered rather than overwritten,
 so prior renders survive.
+
+Say what the diff is against: `--pr <N>` when you abridged a PR, `--commit
+<rev>` when you abridged a commit. Either one puts a link to it on GitHub in
+the header band, so the page can be read beside its source. `--pr` also puts a
+copyable *watch checks, then merge* command at the bottom — the same one the
+`merge` skill runs — behind a copy-to-clipboard button. Leave both off for
+`-w` and `-staged`; there is nothing to link to.
 
 The page carries its own provenance, which is why the flags matter. `--orig`
 lets it derive which files were dropped whole, by comparing `$STATE`'s file list

--- a/bin/meat-view
+++ b/bin/meat-view
@@ -22,6 +22,10 @@ Options:
   --excluded <file>   File holding `meatx prep` stderr, i.e. the generated
                       files it excluded before numbering.
   --note <text>       Prose about what was dropped and why.
+  --pr <number>       The PR this diff is against. Adds a GitHub link to the
+                      header and a copyable watch-checks-then-merge command.
+  --commit <rev>      The commit this diff is against. Adds a GitHub link to
+                      the header. Mutually exclusive with --pr.
   --target <name>     Names the output file: pr-175, worktree, staged, a sha.
                       Defaults to "reading".
   --title <text>      Page title / header line. Defaults to the target.
@@ -35,6 +39,7 @@ Requirements:
   - bunx (renders via diff2html-cli)
   - qopen
   - git
+  - gh (only for --pr, and only to resolve the URL; falls back to the remote)
 """
 
 DIFF2HTML = "diff2html-cli@5.2.15"
@@ -100,12 +105,18 @@ def bullet_list(items):
     return "<ul>" + "".join(f"<li>{html.escape(i)}</li>" for i in items) + "</ul>"
 
 
-def build_band(summary, retention, dropped, excluded, note):
+def build_band(summary, retention, dropped, excluded, note, link):
     parts = []
     if summary:
         parts.append(f'<p class="meat-summary">{rich(summary)}</p>')
 
     chips = []
+    url, label = link
+    if url:
+        chips.append(
+            f'<a class="meat-chip meat-chip-link" href="{html.escape(url, quote=True)}">'
+            f"{html.escape(label)} on GitHub &rarr;</a>"
+        )
     if retention:
         chips.append(f'<span class="meat-chip">{html.escape(retention)}</span>')
     if dropped:
@@ -138,6 +149,73 @@ def build_band(summary, retention, dropped, excluded, note):
             )
         )
     return "\n".join(parts)
+
+
+def git_out(*args):
+    """stdout of a git command, or "" if it failed."""
+    try:
+        r = subprocess.run(
+            ["git", *args], capture_output=True, text=True, check=True
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return ""
+    return r.stdout.strip()
+
+
+def github_base():
+    """https://github.com/<owner>/<repo> for origin, or "" if it isn't GitHub."""
+    url = git_out("remote", "get-url", "origin")
+    m = re.match(r"(?:git@|(?:ssh|https?)://(?:[^@/]+@)?)([^:/]+)[:/](.+?)(?:\.git)?$", url)
+    if not m or "github.com" not in m.group(1):
+        return ""
+    return f"https://github.com/{m.group(2)}"
+
+
+def pr_link(number):
+    """(url, label) for a PR. gh knows the right repo even for forks."""
+    try:
+        url = subprocess.run(
+            ["gh", "pr", "view", str(number), "--json", "url", "-q", ".url"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        url = ""
+    if not url:
+        base = github_base()
+        url = f"{base}/pull/{number}" if base else ""
+    return url, f"PR #{number}"
+
+
+def commit_link(rev):
+    """(url, label) for a commit. The rev is resolved so the link is stable."""
+    base = github_base()
+    sha = git_out("rev-parse", rev)
+    if not base or not sha:
+        return "", ""
+    return f"{base}/commit/{sha}", f"commit {sha[:8]}"
+
+
+def build_footer(number):
+    """A copyable `watch checks, then merge` command — what the merge skill runs."""
+    cmd = (
+        f"gh pr checks {number} --watch > /dev/null "
+        f"&& gh pr checks {number} "
+        f"&& gh pr merge {number} --merge --delete-branch"
+    )
+    return (
+        '<section class="meat-footer">'
+        '<div class="meat-footer-head">'
+        "<h2>Merge when CI is green</h2>"
+        f'<button type="button" class="meat-copy" data-copy="{html.escape(cmd, quote=True)}">'
+        "Copy to clipboard</button>"
+        "</div>"
+        "<p>Blocks until checks finish, prints their final state, and merges only "
+        "if they all passed.</p>"
+        f"<pre>{html.escape(cmd)}</pre>"
+        "</section>"
+    )
 
 
 def output_dir():
@@ -185,9 +263,14 @@ def main():
     p.add_argument("--orig")
     p.add_argument("--excluded")
     p.add_argument("--note")
+    p.add_argument("--pr")
+    p.add_argument("--commit")
     p.add_argument("--target")
     p.add_argument("--title")
     args = p.parse_args()
+
+    if args.pr and args.commit:
+        die("--pr and --commit are mutually exclusive")
 
     for cmd in ("bunx", "qopen", "git"):
         if not shutil.which(cmd):
@@ -209,18 +292,31 @@ def main():
     stem = re.sub(r"[^A-Za-z0-9._-]", "-", target.replace("/", "-")).strip("-") or "reading"
     title = args.title or target
 
-    band = build_band(summary, retention, dropped, excluded, args.note)
+    link = ("", "")
+    if args.pr:
+        link = pr_link(args.pr)
+    elif args.commit:
+        link = commit_link(args.commit)
+    if (args.pr or args.commit) and not link[0]:
+        print("Notice: could not resolve a GitHub URL; rendering without a link.",
+              file=sys.stderr)
+
+    band = build_band(summary, retention, dropped, excluded, args.note, link)
+    footer = build_footer(args.pr) if args.pr else ""
 
     tmpl = read(TEMPLATE)
-    if "<!--meat-header-->" not in tmpl:
-        die(f"{TEMPLATE} is missing the <!--meat-header--> placeholder")
+    for placeholder in ("<!--meat-header-->", "<!--meat-footer-->"):
+        if placeholder not in tmpl:
+            die(f"{TEMPLATE} is missing the {placeholder} placeholder")
 
     out = next_free(output_dir(), stem)
 
     with tempfile.NamedTemporaryFile(
         "w", suffix=".html", delete=False, encoding="utf-8"
     ) as tf:
-        tf.write(tmpl.replace("<!--meat-header-->", band))
+        tf.write(
+            tmpl.replace("<!--meat-header-->", band).replace("<!--meat-footer-->", footer)
+        )
         tmpl_path = tf.name
 
     try:

--- a/bin/meat-view-template.html
+++ b/bin/meat-view-template.html
@@ -10,8 +10,8 @@
       Based on diff2html-cli's stock template.html by rtfpessoa.
       The diff2html-title / diff2html-css / diff2html-js-ui / diff2html-header /
       diff2html-diff comment placeholders and the //diff2html-* script lines are
-      substituted by diff2html-cli; do not remove them. The meat-header comment
-      placeholder is substituted by meat-view itself.
+      substituted by diff2html-cli; do not remove them. The meat-header and
+      meat-footer comment placeholders are substituted by meat-view itself.
     -->
 
     <!--diff2html-css-->
@@ -117,6 +117,15 @@
         border-radius: 999px;
         padding: 2px 10px;
       }
+      .meat-chip-link {
+        color: var(--meat-accent);
+        border-color: var(--meat-accent);
+        text-decoration: none;
+        font-weight: 600;
+      }
+      .meat-chip-link:hover {
+        background: var(--meat-subtle);
+      }
       .meat-chip-warn {
         color: var(--meat-warn);
         background: var(--meat-warn-bg);
@@ -181,6 +190,66 @@
         padding: 16px 20px 60px;
       }
 
+      /* ---- sticky per-file header --------------------------------------
+         diff2html's own rule pins it at top: 0, which puts it under the
+         sticky file list. --meat-listh is that list's live height, set by
+         the ResizeObserver below; the fallback matters only pre-script. */
+      .d2h-file-wrapper .d2h-sticky-header {
+        top: var(--meat-listh, 0px);
+      }
+
+      /* ---- merge footer ------------------------------------------------- */
+
+      .meat-footer {
+        text-align: left;
+        margin: 0 20px 60px;
+        padding: 14px 16px;
+        border: 1px solid var(--meat-border);
+        border-radius: 6px;
+        background: var(--meat-subtle);
+        font-size: 14px;
+      }
+      .meat-footer-head {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+      }
+      .meat-footer h2 {
+        margin: 0;
+        font-size: 14px;
+        font-weight: 600;
+      }
+      .meat-footer p {
+        margin: 6px 0 10px;
+        color: var(--meat-muted);
+      }
+      .meat-footer pre {
+        margin: 0;
+        padding: 10px 12px;
+        overflow-x: auto;
+        border: 1px solid var(--meat-border);
+        border-radius: 4px;
+        background: var(--meat-bg);
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        font-size: 12px;
+      }
+      .meat-copy {
+        flex: none;
+        cursor: pointer;
+        font: inherit;
+        font-size: 12px;
+        color: var(--meat-fg);
+        background: var(--meat-bg);
+        border: 1px solid var(--meat-border);
+        border-radius: 6px;
+        padding: 4px 12px;
+      }
+      .meat-copy:hover {
+        border-color: var(--meat-accent);
+        color: var(--meat-accent);
+      }
+
       /* ---- hidden line numbers ------------------------------------------
          meat's folds make in-hunk line numbers wrong, so they are not shown.
          The gutter itself stays: it is what separates the two sides. */
@@ -201,6 +270,39 @@
         //diff2html-fileContentToggle
         //diff2html-synchronisedScroll
         //diff2html-highlightCode
+        // Not a diff2html-cli placeholder — the CLI has no flag for it, but the
+        // UI bundle does, and it is what keeps each file's name and its Viewed
+        // checkbox on screen while you scroll that file.
+        diff2htmlUi.stickyFileHeaders();
+
+        // The file list is itself sticky and its height changes when it is
+        // toggled open, so the per-file headers have to stack below whatever
+        // it currently is, not below a guess.
+        const fileList = document.querySelector('.d2h-file-list-wrapper');
+        if (fileList) {
+          const track = () =>
+            document.documentElement.style.setProperty(
+              '--meat-listh',
+              fileList.offsetHeight + 'px',
+            );
+          new ResizeObserver(track).observe(fileList);
+          track();
+        }
+
+        document.querySelectorAll('.meat-copy').forEach((button) => {
+          button.addEventListener('click', async () => {
+            const text = button.dataset.copy;
+            try {
+              await navigator.clipboard.writeText(text);
+              button.textContent = 'Copied';
+            } catch {
+              // file:// pages are a secure context in current browsers, so this
+              // is the rare-permission case: leave the text selectable and say so.
+              button.textContent = 'Copy failed — select it';
+            }
+            setTimeout(() => (button.textContent = 'Copy to clipboard'), 2000);
+          });
+        });
       });
     </script>
   </head>
@@ -218,5 +320,7 @@
     <div id="diff">
       <!--diff2html-diff-->
     </div>
+
+    <!--meat-footer-->
   </body>
 </html>


### PR DESCRIPTION
Three changes to `meat-view` and its page template:

- **`--pr <N>` / `--commit <rev>`** put a link to the PR or commit on GitHub in the header band. `--pr` resolves the URL via `gh pr view` (right even for forks) and falls back to parsing `origin`; `--commit` resolves the rev to a full sha first. If neither resolves it prints a notice and renders without a link.
- **Merge footer.** With `--pr`, the page ends with the `merge` skill's command — `gh pr checks N --watch > /dev/null && gh pr checks N && gh pr merge N --merge --delete-branch` — behind a copy-to-clipboard button.
- **Sticky file headers.** The filename and its Viewed checkbox now stay put while you scroll a file. The template calls `stickyFileHeaders()` directly since the cli has no flag for it, and a `ResizeObserver` feeds the sticky file list's live height to `--meat-listh` so the headers stack below it instead of under it.

`agent-skills/meat/SKILL.md` documents the new flags, including leaving them off for `-w` / `-staged`.

Verified in a browser against a real PR: link and footer render with the right URL and command, and the file header reports `position: sticky` at `top: 420px`, matching the file list's height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)