### PR TITLE
Switch Claude Code to the fullscreen TUI renderer

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -126,5 +126,6 @@
     "type": "command"
   },
   "teammateMode": "tmux",
-  "theme": "auto"
+  "theme": "auto",
+  "tui": "fullscreen"
 }


### PR DESCRIPTION
Sets `"tui": "fullscreen"` in `claude/settings.json`, which selects the flicker-free alt-screen renderer with virtualized scrollback (equivalent to `CLAUDE_CODE_NO_FLICKER=1`) instead of the classic main-screen renderer.

It self-disables in environments that can't render it correctly (`tmux -CC`, Windows over SSH), so there's no fallback to manage here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)