### PR TITLE
Make pocock-implement agent-invocable again

### DIFF
--- a/agent-skills/ATTRIBUTION.md
+++ b/agent-skills/ATTRIBUTION.md
@@ -17,3 +17,12 @@ local directory name minus the `pocock-` prefix — e.g. `pocock-tdd` comes from
 upstream's `skills/engineering/setup-matt-pocock-skills`.
 
 Skills in this directory *without* the `pocock-` prefix are not Matt's.
+
+## Local deviations
+
+Two edits go beyond the mechanical rename, and a resync has to reapply them:
+
+- `pocock-implement` drops upstream's `disable-model-invocation: true`, so an agent
+  can reach for the skill on its own.
+- `pocock-wizard/template.sh` carries a `shellcheck disable=SC2034` for its color
+  palette, which exists for the stages an author writes below the marker.

--- a/agent-skills/pocock-implement/SKILL.md
+++ b/agent-skills/pocock-implement/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pocock-implement
 description: "Implement a piece of work based on a spec or set of tickets."
-disable-model-invocation: true
 ---
 
 Implement the work described by the user in the spec or tickets.


### PR DESCRIPTION
The upstream resync in f2839fe restored `disable-model-invocation: true` on `pocock-implement`, undoing 8b2b2ab. The skill went back to being reachable only by typing `/pocock-implement` — an agent couldn't reach for it on its own.

Drops the flag again. Unlike 8b2b2ab, this keeps upstream's description as-is.

`pocock-implement` was the only regression: `pocock-to-questionnaire` and `pocock-wait-what` also carry the flag, but they're new in the resync and were never agent-invocable here.

Also adds a "Local deviations" section to `agent-skills/ATTRIBUTION.md` covering this and the `pocock-wizard/template.sh` shellcheck disable, since the file otherwise claims the port is purely mechanical — which is how this got reverted in the first place.

`make lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)