### PR TITLE
Add Smart Start: switch models at the first file edit

### DIFF
--- a/bin/smart-start
+++ b/bin/smart-start
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -eu
+
+if [[ "${1:-}" == "-h" ]] || [[ "${1:-}" == "--help" ]]; then
+    cat <<EOF
+Usage: smart-start <start-model> <then-model> [claude args...]
+
+Launch Claude Code in Smart Start mode: an expensive model for the reading
+and planning, a cheaper one from the first file edit onward.
+
+Sugar for: SMART_START_THEN=<then-model> claude --model <start-model>
+
+The switch is done by the PostToolUse hook in claude/bin/smart-start-switch.sh,
+which drives /model over tmux — so this only does anything inside tmux.
+
+Examples:
+  smart-start opus sonnet             - Plan on Opus, implement on Sonnet
+  smart-start fable opus --continue   - Extra args are passed to claude
+EOF
+    exit 0
+fi
+
+if [ $# -lt 2 ]; then
+    echo "usage: smart-start <start-model> <then-model> [claude args...]" >&2
+    exit 1
+fi
+
+start_model=$1
+then_model=$2
+shift 2
+
+if [ -z "${TMUX:-}" ]; then
+    echo "smart-start: not in tmux — the model switch will not fire" >&2
+fi
+
+SMART_START_THEN=$then_model exec claude --model "$start_model" "$@"

--- a/claude/bin/smart-start-switch.sh
+++ b/claude/bin/smart-start-switch.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+# Smart Start — switch models at the first main-loop file edit.
+#
+# Registered as a PostToolUse hook on Edit|Write. Inert unless
+# SMART_START_THEN names the model to switch to; `smart-start` sets it.
+#
+# The expensive model does the reading and planning; the moment it makes its
+# first real edit this halts the turn, drives /model over tmux, and tells it to
+# continue — so the cheap model finishes the work with the expensive model's
+# exploration already in context instead of re-deriving it.
+#
+# SMART_START_DELAY tunes the seconds spent waiting for the turn to halt.
+set -eu
+
+[ -n "${SMART_START_THEN:-}" ] || exit 0
+[ -n "${TMUX_PANE:-}" ] || exit 0
+
+# A stale pane would mean halting the turn with no way to restart it, so make
+# sure the keystrokes have somewhere to land before committing to the switch.
+# (send-keys to a missing pane fails, but display-message silently retargets
+# the current pane, so list the panes rather than probing the target.)
+tmux list-panes -a -F '#{pane_id}' 2>/dev/null | grep -qxF "$TMUX_PANE" || exit 0
+
+input=$(cat)
+
+# Subagent edits aren't the main loop handing off its own reasoning, and
+# subagents may already be running a cheaper tier.
+[ -z "$(printf '%s' "$input" | jq -r '.agent_id // ""')" ] || exit 0
+
+session_id=$(printf '%s' "$input" | jq -r '.session_id // ""')
+[ -n "$session_id" ] || exit 0
+
+# One switch per session, latched atomically — a failed mkdir means either
+# already switched or nowhere to write, and both should leave the model alone.
+# /clear mints a new session id, which re-arms: after a clear you're exploring
+# from scratch again. The ##*/ keeps a stray slash from escaping the temp dir.
+mkdir "${TMPDIR:-/tmp}/smart-start-${session_id##*/}" 2>/dev/null || exit 0
+
+# Keys sent to the pane mid-turn queue instead of submitting, so wait for the
+# halt below to land them on an idle prompt. Detached from this hook's stdio so
+# Claude Code isn't left waiting on the pipe.
+(
+    sleep "${SMART_START_DELAY:-1}"
+    tmux send-keys -t "$TMUX_PANE" "/model $SMART_START_THEN" Enter
+    sleep 0.5
+    tmux send-keys -t "$TMUX_PANE" Enter
+    tmux send-keys -t "$TMUX_PANE" continue Enter
+) >/dev/null 2>&1 &
+
+jq -cn --arg model "$SMART_START_THEN" \
+    '{continue: false, stopReason: "Smart Start: switching to \($model), then continuing automatically."}'

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -32,6 +32,17 @@
         "matcher": "permission_prompt"
       }
     ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "command": "$HOME/.claude/bin/smart-start-switch.sh",
+            "type": "command"
+          }
+        ],
+        "matcher": "Edit|Write"
+      }
+    ],
     "PreToolUse": [
       {
         "hooks": [


### PR DESCRIPTION
Start a session on an expensive model for reading and planning, then hand the
work to a cheaper one the moment real implementation begins. The expensive
model's exploration is already in context, so the cheap model doesn't re-derive
it — and it's primed to explore further in a smart way.

```sh
smart-start opus sonnet
# or, equivalently:
SMART_START_THEN=sonnet claude --model opus
```

## How it works

A `PostToolUse` hook on `Edit|Write` fires at the first real edit and:

1. bails unless `SMART_START_THEN` is set, so it's inert by default;
2. bails if `$TMUX_PANE` is missing or no longer names a live pane — a stale
   pane would halt the turn with no way to restart it;
3. bails on subagent edits (`agent_id` present) — a subagent edit isn't the main
   loop handing off its own reasoning, and subagents may already be cheap;
4. latches once per session via `mkdir` keyed by `session_id`. `/clear` mints a
   new id, which re-arms — right, since after a clear you're exploring again;
5. backgrounds the keystrokes and returns `{"continue": false}` to halt the
   turn. Keys sent mid-turn queue instead of submitting, so the delay lets them
   land on an idle prompt: `/model <then>`, confirm, then `continue`.

## Notes

- Needs tmux; `smart-start` warns if you're not in it.
- `SMART_START_DELAY` tunes the halt wait (default 1s). Too long is harmless;
  too short degrades to the queued case.
- `/model` also writes the global default, which dirties the source-controlled
  `claude/settings.json`. Accepted — `git checkout` restores it.

## Testing

Verified with a stubbed `tmux`: inert when the var is unset, skips subagent
edits, skips a stale pane, fires exactly once per session, re-arms on a new
session id, and emits the right keystroke sequence. `make lint` passes.

`make test` was not run — the Docker image fails to build on the nvim install
step, which is pre-existing and unrelated (the Dockerfile is untouched here),
and the suite covers zsh functions, which this doesn't touch.

The one thing only a real run can prove is whether the backgrounded send lands
on an idle prompt after `continue: false` halts the turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)