### PR TITLE
Fix meat-view's merge command and Viewed-checkbox scroll

### DIFF
--- a/bin/meat-view
+++ b/bin/meat-view
@@ -200,9 +200,10 @@ def commit_link(rev):
 def build_footer(number):
     """A copyable `watch checks, then merge` command — what the merge skill runs."""
     cmd = (
-        f"gh pr checks {number} --watch > /dev/null "
-        f"&& gh pr checks {number} "
-        f"&& gh pr merge {number} --merge --delete-branch"
+        f"PR={number}; "
+        'gh pr checks "$PR" --watch > /dev/null '
+        '&& gh pr checks "$PR" '
+        '&& gh pr merge "$PR" --merge --delete-branch'
     )
     return (
         '<section class="meat-footer">'

--- a/bin/meat-view-template.html
+++ b/bin/meat-view-template.html
@@ -289,6 +289,28 @@
           track();
         }
 
+        // Checking a file's Viewed box collapses it, and everything below
+        // jumps up by the height of what just vanished — so you land mid-hunk
+        // in the next file with its opening lines already scrolled past.
+        // Re-anchor on the file you just folded, under the sticky file list,
+        // so the next one starts at the top of the frame. Delegated because
+        // stickyFileHeaders may re-render the headers these boxes live in.
+        document.addEventListener('change', (event) => {
+          const box = event.target.closest?.('.d2h-file-collapse-input');
+          if (!box || !box.checked) return;
+          const wrapper = box.closest('.d2h-file-wrapper');
+          if (!wrapper) return;
+          // Next frame, so the position measured is the post-collapse one:
+          // diff2html's own change handler runs on this same event.
+          requestAnimationFrame(() => {
+            const listHeight = fileList ? fileList.offsetHeight : 0;
+            window.scrollTo({
+              top: window.scrollY + wrapper.getBoundingClientRect().top - listHeight,
+              behavior: 'smooth',
+            });
+          });
+        });
+
         document.querySelectorAll('.meat-copy').forEach((button) => {
           button.addEventListener('click', async () => {
             const text = button.dataset.copy;


### PR DESCRIPTION
Two small fixes to the page `meat-view` renders.

**Merge command writes the PR number once.** The footer's copyable *watch checks, then merge* command spelled `175` three times; it now binds `PR=175` up front and refers to `"$PR"` after, so a copied command is edited in one place instead of three.

**Viewed checkbox re-anchors the scroll.** Checking a file's Viewed box collapses it, and everything below jumps up by the height of what just vanished — so you land mid-hunk in the next file with its opening lines already scrolled past. A delegated `change` listener now scrolls the just-folded file to the top of the viewport, offset by the sticky file list's live height. It runs in a `requestAnimationFrame` so it measures the post-collapse layout (diff2html's own handler fires on the same event), and only fires on check, not uncheck.

Verified in a real browser: scrolled deep into the second file, clicked Viewed, and after the smooth scroll settled the folded file's top sat at 301px — exactly the sticky list height — with the next file starting at 365px, fully visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)