### PR TITLE
Keep case tables in meat, and snap instead of scroll

### DIFF
--- a/agent-skills/meat/SKILL.md
+++ b/agent-skills/meat/SKILL.md
@@ -98,7 +98,8 @@ What to cut, in rough priority order:
   in full; `remove` the rest outright. This is usually the single biggest win.
 - **Test bodies.** Keep the `it(`/`test(`/`def test_` names — they are the
   contract, and reading them in a list is the fastest way to see what the change
-  claims. Fold the mock setup and assertion blocks under each.
+  claims. Fold the mock setup and assertion blocks under each. **Except for
+  data-driven tests** — see below.
 - **Mechanical function bodies** — env plumbing, URL building, JSON marshalling,
   error-message construction, field-by-field copies.
 - **Whole hunks that survive only as context** after imports are stripped.
@@ -108,6 +109,14 @@ What to keep, always:
 - Doc comments and rationale. In this codebase they carry the design argument —
   the *why* — which is exactly what a reviewer cannot reconstruct from the code.
 - Type and interface declarations, exported signatures.
+- **Case tables in data-driven tests.** `it.each` / `test.each` / `@parametrize`
+  / a Go `tests := []struct{...}` literal invert the usual test rule: the title
+  is one generic template (`"joins %o into %s"`) and the *rows* are the contract.
+  Folding the table leaves a test whose meaning is unrecoverable — the reader
+  cannot even tell what the input shape was. Keep every row. Fold the runner
+  body under it instead; that part is the boilerplate here. Only fold rows when
+  a table runs past ~25 of them and they are visibly homogeneous, and then keep
+  the first few and the edge cases and fold the middle.
 - Control flow, conditions, lifecycle edges, retry/backoff decisions, security
   boundaries, and anything a comment flags as a caveat or hazard.
 

--- a/bin/meat-view-template.html
+++ b/bin/meat-view-template.html
@@ -306,7 +306,9 @@
             const listHeight = fileList ? fileList.offsetHeight : 0;
             window.scrollTo({
               top: window.scrollY + wrapper.getBoundingClientRect().top - listHeight,
-              behavior: 'smooth',
+              // Instant, not smooth: the collapse and the scroll animating at
+              // once makes it hard to see which file you just folded.
+              behavior: 'instant',
             });
           });
         });


### PR DESCRIPTION
Two fixes to reading diffs, both about not losing the thing you were trying to read.

## Case tables in data-driven tests

meat's test rule was *keep the `it()`/`test()` names, fold the bodies*. That inverts for data-driven tests: the title is one generic template (`"joins %o into %s"`) and the **rows** are the contract. Folding the table left tests whose meaning was unrecoverable — the reader couldn't even tell what the input shape was.

The old rule wasn't ambiguous, it was confidently wrong for this shape, so there was no signal for the agent to stop and think. The carve-out is therefore in **both** places — at the cut rule and in the keep list — so whichever one the agent reaches first redirects it. Names the four common forms (`it.each`, `test.each`, `@parametrize`, Go table structs) and folds the *runner* body instead, with an escape hatch for tables past ~25 homogeneous rows.

## Instant re-anchor on Viewed

The scroll that re-anchors on the file you just collapsed was animated, so the fold and the travel happened at once and you couldn't see which file you'd folded. Snap instead. `'instant'` is explicit rather than dropping the key, since the default `'auto'` would inherit any `scroll-behavior: smooth` that later shows up in CSS.

Anchor math is unchanged — same landing spot, no travel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)