### PR TITLE
Fix meat-view merge command, PR link target, and Viewed reset

### DIFF
--- a/agent-skills/merge/SKILL.md
+++ b/agent-skills/merge/SKILL.md
@@ -9,7 +9,7 @@ If a PR merge is intended, follow these steps:
 
 1. Get the current PR number using `gh pr view --json number -q .number`
 
-2. Wait for CI to finish using `gh pr checks <number> --watch > /dev/null && gh pr checks <number>` — the first call blocks until checks complete (discarding its noisy per-refresh output), and the second produces one clean final-state block. Use a generous timeout on the Bash call.
+2. Wait for CI to finish using `gh pr checks <number> --watch --fail-fast > /dev/null; gh pr checks <number>` — the first call blocks until checks complete (discarding its noisy per-refresh output), and the second produces one clean final-state block. Note the `;` rather than `&&`: watch mode exits 1 on failure and 8 while pending, so chaining with `&&` would swallow the final-state block in exactly the case you need to see it. Use a generous timeout on the Bash call.
 
 3. Based on the final result:
    - **If all checks passed**: Proceed to merge immediately

--- a/bin/meat-view
+++ b/bin/meat-view
@@ -114,7 +114,8 @@ def build_band(summary, retention, dropped, excluded, note, link):
     url, label = link
     if url:
         chips.append(
-            f'<a class="meat-chip meat-chip-link" href="{html.escape(url, quote=True)}">'
+            f'<a class="meat-chip meat-chip-link" href="{html.escape(url, quote=True)}" '
+            'target="_blank" rel="noopener">'
             f"{html.escape(label)} on GitHub &rarr;</a>"
         )
     if retention:
@@ -201,8 +202,8 @@ def build_footer(number):
     """A copyable `watch checks, then merge` command — what the merge skill runs."""
     cmd = (
         f"PR={number}; "
-        'gh pr checks "$PR" --watch > /dev/null '
-        '&& gh pr checks "$PR" '
+        'gh pr checks "$PR" --watch --fail-fast > /dev/null; '
+        'gh pr checks "$PR" '
         '&& gh pr merge "$PR" --merge --delete-branch'
     )
     return (

--- a/bin/meat-view-template.html
+++ b/bin/meat-view-template.html
@@ -275,6 +275,18 @@
         // checkbox on screen while you scroll that file.
         diff2htmlUi.stickyFileHeaders();
 
+        // Browsers restore checkbox state across a reload, but the collapse
+        // those boxes drive is runtime-only — so a refresh would show every
+        // file expanded with its Viewed box still ticked. Start clean. The
+        // pageshow pass covers the back/forward cache, which restores the
+        // whole page without firing DOMContentLoaded again.
+        const clearViewed = () =>
+          document
+            .querySelectorAll('.d2h-file-collapse-input')
+            .forEach((box) => (box.checked = false));
+        clearViewed();
+        window.addEventListener('pageshow', clearViewed);
+
         // The file list is itself sticky and its height changes when it is
         // toggled open, so the per-file headers have to stack below whatever
         // it currently is, not below a guess.


### PR DESCRIPTION
Three small fixes to the meat HTML viewer.

**Merge command exit codes.** The copyable command chained the blocking watch call into the rest with `&&`:

```
gh pr checks "$PR" --watch > /dev/null && gh pr checks "$PR" && gh pr merge ...
```

`gh pr checks` exits 1 on failure and 8 while pending — in watch mode too ([checks.go](https://github.com/cli/cli/blob/trunk/pkg/cmd/pr/checks/checks.go) returns `SilentError`/`PendingError` after the watch loop). So the merge gate was never actually broken, but on a red build the chain short-circuited at the watch call, whose output goes to `/dev/null` — printing nothing at all. Switched to `;` so the second `gh pr checks` always renders the final state, and added `--fail-fast` so a failure stops the wait instead of sitting through the remaining jobs. Same fix applied to the merge skill's instructions.

**PR link opens in a new tab**, so following it doesn't discard your place in the diff.

**Viewed checkboxes reset on load.** They're static markup, so browsers restore their checked state across a refresh — but the collapse they drive is runtime-only, leaving ticked boxes sitting over fully expanded files. Cleared on `DOMContentLoaded` plus `pageshow` for the back/forward cache.

## Testing

Rendered a page and drove it in Chromium: the link carries `target="_blank" rel="noopener"`, the footer command is correct, collapsing still works, and a simulated restore clears the boxes.

Caveat worth stating: headless Chromium doesn't restore form state on reload at all — a copy of the page with the fix stripped out behaved identically — so the refresh symptom itself was not reproduced end to end. The reasoning rests on the checkboxes being static markup with no `autocomplete="off"`. Worth a quick real-browser refresh to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)