### PR TITLE
Remove teammateMode setting from Claude config

### DIFF
--- a/claude/settings.json
+++ b/claude/settings.json
@@ -136,7 +136,6 @@
     "command": "$HOME/.claude/bin/statusline.sh",
     "type": "command"
   },
-  "teammateMode": "tmux",
   "theme": "auto",
   "tui": "fullscreen"
 }


### PR DESCRIPTION
Drops the `teammateMode: tmux` entry from `claude/settings.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)