### PR TITLE
Render meat-view notes as paragraphs

### DIFF
--- a/bin/meat-view
+++ b/bin/meat-view
@@ -93,6 +93,12 @@ def rich(text):
     return re.sub(r"`([^`]+)`", r"<code>\1</code>", html.escape(text))
 
 
+def paragraphs(text):
+    """Blank-line-separated prose as <p> blocks; single newlines stay soft wraps."""
+    blocks = [b.strip() for b in re.split(r"\n[ \t]*\n", text.strip())]
+    return "".join(f"<p>{rich(b)}</p>" for b in blocks if b)
+
+
 def details(summary, body_html, open_=False):
     attr = " open" if open_ else ""
     return (
@@ -132,7 +138,7 @@ def build_band(summary, retention, dropped, excluded, note, link):
     parts.append('<div class="meat-facts">' + "".join(chips) + "</div>")
 
     if note:
-        parts.append(f'<p class="meat-note">{rich(note)}</p>')
+        parts.append(f'<div class="meat-note">{paragraphs(note)}</div>')
 
     if dropped:
         parts.append(

--- a/bin/meat-view-template.html
+++ b/bin/meat-view-template.html
@@ -137,6 +137,12 @@
         border-left: 3px solid var(--meat-border);
         color: var(--meat-fg);
       }
+      .meat-note p {
+        margin: 0 0 8px;
+      }
+      .meat-note p:last-child {
+        margin-bottom: 0;
+      }
       .meat-details {
         margin-top: 8px;
       }


### PR DESCRIPTION
`--note` prose written with blank lines between paragraphs was emitted inside a single `<p>`, so the browser collapsed it into one wall of text — see the note band on a recent `pr-273.html` render.

- `meat-view` now splits the note on blank lines and emits one `<p>` per paragraph, inside a `<div class="meat-note">`. Single newlines stay soft wraps, as before.
- Template gets `.meat-note p` spacing so the paragraphs breathe and the quote border still spans them all.

No skill change: agents were already writing multi-paragraph notes correctly; only the renderer discarded the breaks.

Verified by rendering a sample diff with a two-paragraph note: output is `<div class="meat-note"><p>…</p><p>…</p></div>`. `make lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)