### PR TITLE
Add comment-trimming step to pocock-implement

### DIFF
--- a/agent-skills/pocock-implement/SKILL.md
+++ b/agent-skills/pocock-implement/SKILL.md
@@ -9,6 +9,8 @@ Use /pocock-tdd where possible, at pre-agreed seams.
 
 Run typechecking regularly, single test files regularly, and the full test suite once at the end.
 
+Cut comments to the bare minimum.
+
 Once done, use /pocock-code-review to review the work.
 
 Commit your work to the current branch.


### PR DESCRIPTION
Adds one instruction to the pocock-implement skill, in the same voice and brevity as the surrounding lines: cut comments to the bare minimum, placed just before the code-review step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)